### PR TITLE
Fix ssh-to-pgp tests on darwin by using /tmp

### DIFF
--- a/pkgs/ssh-to-pgp/main_test.go
+++ b/pkgs/ssh-to-pgp/main_test.go
@@ -27,6 +27,10 @@ func TestCli(t *testing.T) {
 	ok(t, err)
 	defer os.RemoveAll(tempdir)
 
+	gpgHome := path.Join(tempdir, "gpg-home")
+	gpgEnv := append(os.Environ(), fmt.Sprintf("GNUPGHOME=%s", gpgHome))
+	ok(t, os.Mkdir(gpgHome, os.FileMode(0700)))
+
 	out := path.Join(tempdir, "out")
 	privKey := path.Join(assets, "id_rsa")
 	cmds := [][]string{
@@ -41,6 +45,7 @@ func TestCli(t *testing.T) {
 		cmd := exec.Command("gpg", "--with-fingerprint", "--show-key", out)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Env = gpgEnv
 		ok(t, cmd.Run())
 	}
 }

--- a/pkgs/ssh-to-pgp/main_test.go
+++ b/pkgs/ssh-to-pgp/main_test.go
@@ -23,7 +23,7 @@ func ok(tb testing.TB, err error) {
 func TestCli(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	assets := path.Join(path.Dir(filename), "test-assets")
-	tempdir, err := ioutil.TempDir("", "testdir")
+	tempdir, err := ioutil.TempDir("/tmp", "testdir")
 	ok(t, err)
 	defer os.RemoveAll(tempdir)
 

--- a/pkgs/ssh-to-pgp/main_test.go
+++ b/pkgs/ssh-to-pgp/main_test.go
@@ -20,10 +20,19 @@ func ok(tb testing.TB, err error) {
 	}
 }
 
+func TempRoot() string {
+	if runtime.GOOS == "darwin" {
+		// macOS make its TEMPDIR long enough for unix socket to break
+		return "/tmp"
+	} else {
+		return os.TempDir()
+	}
+}
+
 func TestCli(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	assets := path.Join(path.Dir(filename), "test-assets")
-	tempdir, err := ioutil.TempDir("/tmp", "testdir")
+	tempdir, err := ioutil.TempDir(TempRoot(), "testdir")
 	ok(t, err)
 	defer os.RemoveAll(tempdir)
 


### PR DESCRIPTION
This PR adjusts the GNUPGHOME directory to be directly under /tmp, so that the generated directory name doesn't exceed gpg-agent's file name limit. This fixes #14 for me, but may be broken for windows users.