### PR TITLE
sops-install-secrets: symlinkSecret: set uid/gid (with Fchownat)

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -158,7 +158,7 @@ func symlinkSecret(targetFile string, secret *secret) error {
 				return fmt.Errorf("Cannot create symlink '%s': %w", secret.Path, err)
 			}
 			if err := secureSymlinkChown(secret.Path, targetFile, secret.owner, secret.group); err != nil {
-				return fmt.Errorf("Cannot secure symlink '%s': %w", secret.Path, err)
+				return fmt.Errorf("Cannot chown symlink '%s': %w", secret.Path, err)
 			}
 			return nil
 		} else if err != nil {


### PR DESCRIPTION
To keep the existing state machine logic to ensure symlink... this also checks existing symlinks to make sure they're owner/group are correct.

Fixes #30 