### PR TITLE
Keep the original shellHook if it is set, and run it after `sopsPGPHook`

### DIFF
--- a/pkgs/sops-pgp-hook/sops-pgp-hook.bash
+++ b/pkgs/sops-pgp-hook/sops-pgp-hook.bash
@@ -27,4 +27,6 @@ sopsPGPHook() {
 
 if [ -z "${shellHook-}" ]; then
   shellHook=sopsPGPHook
+else
+  shellHook="sopsPGPHook;${shellHook}"
 fi


### PR DESCRIPTION
Closes: #59 