### PR TITLE
Fix flake build

### DIFF
--- a/.github/workflows/test-flakes.yml
+++ b/.github/workflows/test-flakes.yml
@@ -1,0 +1,31 @@
+name: "Flake test"
+on:
+  pull_request:
+  schedule:
+    - cron:  '51 2 * * *'
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          # Nix Flakes doesn't work on shallow clones
+          fetch-depth: 0
+    - uses: cachix/install-nix-action@v12
+      with:
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          system-features = nixos-test benchmark big-parallel kvm
+    - name: Setup cachix
+      uses: cachix/cachix-action@v8
+      with:
+        name: mic92
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - name: List flake structure
+      run: nix flake show
+    - name: Run unit tests (flake)
+      run: nix build --no-link .#unit-tests -L

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,9 @@
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
   in {
     nixosModules.sops = import ./modules/sops;
-    packages = forAllSystems (system: nixpkgs.legacyPackages.${system}.callPackage ./default.nix {});
+    packages = forAllSystems (system: import ./default.nix {
+      pkgs = import nixpkgs { inherit system; };
+    });
     defaultPackage = forAllSystems (system: self.packages.${system}.sops-init-gpg-key);
   };
 }

--- a/pkgs/sops-install-secrets/nixos-test.nix
+++ b/pkgs/sops-install-secrets/nixos-test.nix
@@ -20,6 +20,7 @@
   '';
  } {
    inherit pkgs;
+   inherit (pkgs) system;
  };
 
  pgp-keys = makeTest {
@@ -73,5 +74,6 @@
   '';
  } {
    inherit pkgs;
+   inherit (pkgs) system;
  };
 }


### PR DESCRIPTION
The flake build did not work on the latest master, specifically `nix flake show` and `nix build .#unit-tests`. I fixed the issues and added basic checks to the CI build to prevent regressions.

Checks are not configured yet, so `nix flake check -L` does not work.