### PR TITLE
pkgs: don't reference deprecated stdenv.lib

### DIFF
--- a/pkgs/sops-init-gpg-key/default.nix
+++ b/pkgs/sops-init-gpg-key/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, gnupg, coreutils, utillinux, unixtools }:
+{ stdenv, lib, makeWrapper, gnupg, coreutils, utillinux, unixtools }:
 
 stdenv.mkDerivation {
   name = "sops-init-gpg-key";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   installPhase = ''
     install -m755 -D $src $out/bin/sops-init-gpg-key
     wrapProgram $out/bin/sops-init-gpg-key \
-      --prefix PATH : ${stdenv.lib.makeBinPath [
+      --prefix PATH : ${lib.makeBinPath [
         coreutils utillinux gnupg unixtools.hostname
       ]}
   '';

--- a/pkgs/sops-install-secrets/default.nix
+++ b/pkgs/sops-install-secrets/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, path, pkgs, vendorSha256, go }:
+{ stdenv, lib, buildGoModule, path, pkgs, vendorSha256, go }:
 buildGoModule {
   pname = "sops-install-secrets";
   version = "0.0.1";
@@ -28,7 +28,7 @@ buildGoModule {
 
   inherit vendorSha256;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Atomic secret provisioning based on sops";
     homepage = "https://github.com/Mic92/sops-nix";
     license = licenses.mit;

--- a/pkgs/ssh-to-pgp/default.nix
+++ b/pkgs/ssh-to-pgp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule, gnupg, vendorSha256, }:
+{ stdenv, lib, buildGoModule, gnupg, vendorSha256, }:
 buildGoModule {
   pname = "ssh-to-pgp";
   version = "0.0.1";
@@ -16,7 +16,7 @@ buildGoModule {
 
   inherit vendorSha256;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Convert ssh public/private keys to PGP";
     homepage = "https://github.com/Mic92/sops-nix";
     license = licenses.mit;


### PR DESCRIPTION
`stdenv.lib` has been deprecated in favor of using `lib` directly.
