### PR TITLE
Fix sops-pgp-hook erroring in a strict shell

### DIFF
--- a/pkgs/sops-pgp-hook/sops-pgp-hook.bash
+++ b/pkgs/sops-pgp-hook/sops-pgp-hook.bash
@@ -5,20 +5,20 @@ _sopsAddKey() {
   fpr=$(@gpg@ --with-fingerprint --with-colons --show-key "$key" \
          | awk -F: '$1 == "fpr" { print $10; exit }')
   if [[ $fpr != "" ]]; then
-      export SOPS_PGP_FP=''${SOPS_PGP_FP}''${SOPS_PGP_FP:+','}$fpr
+      export SOPS_PGP_FP=''${SOPS_PGP_FP-}''${SOPS_PGP_FP:+','}$fpr
   fi
 }
 
 sopsPGPHook() {
   local key dir
-  for key in $sopsPGPKeys; do
+  for key in ${sopsPGPKeys-}; do
     if [[ -f "$key" ]]; then
         _sopsAddKey "$key"
     else
         echo "$key does not exists" >&2
     fi
   done
-  for dir in $sopsPGPKeyDirs; do
+  for dir in ${sopsPGPKeyDirs-}; do
     while IFS= read -r -d '' key; do
       _sopsAddKey "$key"
     done < <(find -L "$dir" -type f \( -name '*.gpg' -o -name '*.asc' \) -print0)


### PR DESCRIPTION
Fixes #80 