### PR TITLE
module: Don't set option-value as option-default

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -6,6 +6,9 @@ let
   cfg = config.sops;
   users = config.users.users;
   secretType = types.submodule ({ config, ... }: {
+    config = {
+      sopsFile = lib.mkOptionDefault cfg.defaultSopsFile;
+    };
     options = {
       name = mkOption {
         type = types.str;
@@ -62,7 +65,7 @@ let
       };
       sopsFile = mkOption {
         type = types.path;
-        default = cfg.defaultSopsFile;
+        defaultText = "\${config.sops.defaultSopsFile}";
         description = ''
           Sops file the secret is loaded from.
         '';


### PR DESCRIPTION
When using `documentation.nixos.includeAllModules = true;`, I'd
otherwise have to rebuild the manual on each change since I have my
`defaultSopsFile` in a git-repo with all my other configs.