### PR TITLE
add readonly option sopsFileHash

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -70,6 +70,14 @@ let
           Sops file the secret is loaded from.
         '';
       };
+      sopsFileHash = mkOption {
+        type = types.str;
+        readOnly = true;
+        default = if cfg.validateSopsFiles then "${builtins.hashFile "sha256" config.sopsFile}" else "";
+        description = ''
+          Hash of the sops file, useful in systemd.services.<name>.restartTriggers.
+        '';
+      };
     };
   });
   manifest = pkgs.writeText "manifest.json" (builtins.toJSON {


### PR DESCRIPTION
When secrets are changed, the related services are unlikely to be automatically restarted/reloaded. However `systemd.services.<name>.restartTriggers` can be utilized to achieve that, given that we hash the corresponding sops file beforehand. Another approach can be that we prepend the hash to the path of the secret.