### PR TITLE
modules/sops: fix manual

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -8,6 +8,7 @@ let
   secretType = types.submodule ({ config, ... }: {
     config = {
       sopsFile = lib.mkOptionDefault cfg.defaultSopsFile;
+      sopsFileHash = mkOptionDefault (optionalString cfg.validateSopsFiles "${builtins.hashFile "sha256" config.sopsFile}");
     };
     options = {
       name = mkOption {
@@ -73,9 +74,8 @@ let
       sopsFileHash = mkOption {
         type = types.str;
         readOnly = true;
-        default = if cfg.validateSopsFiles then "${builtins.hashFile "sha256" config.sopsFile}" else "";
         description = ''
-          Hash of the sops file, useful in systemd.services.<name>.restartTriggers.
+          Hash of the sops file, useful in <xref linkend="opt-systemd.services._name_.restartTriggers" />.
         '';
       };
     };


### PR DESCRIPTION
* Since 0d957142b6669dcd138fc3518f69d15432c6dcd5 the manual doesn't
  build since `<name>` is interpreted by docbook as (unmatched) XML-tag.
  I decided to use `<xref linkend` as this provides proper linking to
  the referenced option.

* Also, if the module is included on a machine where `sops` isn't used,
  but `documentation.nixos.includeAllModules = true;` is set, the module
  wouldn't evaluate because `config.sopsFile` is referenced in a
  `default`-tag. This is generally an issue since every change to this
  option would trigger a rebuild of the manual anyways.

  See also 94fd200305ceb031380381ae91a1ffabe9f06706 for that.

cc @Mic92 @NickCao 