### PR TITLE
Add aarch64-darwin to supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
       "x86_64-linux"
       "i686-linux"
       "x86_64-darwin"
+      "aarch64-darwin"
       "aarch64-linux"
       "armv6l-linux"
       "armv7l-linux"


### PR DESCRIPTION
Ran into an issue on my M1 macbook because `aarch64-darwin` wasn't in the supported systems list. This PR adds it, I'm assuming it won't break anything existing.