### PR TITLE
Swap order of age ssh keys and the key file

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -645,15 +645,15 @@ func installSecrets(args []string) error {
 		os.Setenv("GNUPGHOME", manifest.GnupgHome)
 	}
 
-	if len(manifest.AgeSshKeyPaths) != 0 {
+	if manifest.AgeKeyFile != "" {
+		os.Setenv("SOPS_AGE_KEY_FILE", manifest.AgeKeyFile)
+	} else if len(manifest.AgeSshKeyPaths) != 0 {
 		keyfile := filepath.Join(manifest.SecretsMountPoint, "age-keys.txt")
 		err = importAgeSSHKeys(manifest.AgeSshKeyPaths, keyfile)
 		if err != nil {
 			return err
 		}
 		os.Setenv("SOPS_AGE_KEY_FILE", keyfile)
-	} else if manifest.AgeKeyFile != "" {
-		os.Setenv("SOPS_AGE_KEY_FILE", manifest.AgeKeyFile)
 	}
 
 	if err := decryptSecrets(manifest.Secrets); err != nil {


### PR DESCRIPTION
It makes more sense to import the key when we have one and ignore the
SSH keys instead of only importing the key when we have no SSH keys.
This is because we import all SSH keys by default in the module and
using a key file means the use has to explicitly unset the SSH keys.