### PR TITLE
Allow paths in sops.environment

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -192,7 +192,7 @@ in {
     };
 
     environment = mkOption {
-      type = types.attrsOf types.str;
+      type = types.attrsOf (types.either types.str types.path);
       default = {};
       description = ''
         Environment variables to set before calling sops-install-secrets.


### PR DESCRIPTION
Useful for things like `sops.environment.SOPS_GPG_EXEC = pkgs.writeShellScript ...`