### PR TITLE
Add package option to module

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -5,7 +5,7 @@ with lib;
 let
   cfg = config.sops;
   users = config.users.users;
-  sops-install-secrets = (pkgs.callPackage ../.. {}).sops-install-secrets;
+  sops-install-secrets = cfg.package;
   regularSecrets = lib.filterAttrs (_: v: !v.neededForUsers) cfg.secrets;
   secretsForUsers = lib.filterAttrs (_: v: v.neededForUsers) cfg.secrets;
   secretType = types.submodule ({ config, ... }: {
@@ -213,6 +213,15 @@ in {
 
         This will be evaluated twice when using secrets that use neededForUsers but
         in a subshell each time so the environment variables don't collide.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = (pkgs.callPackage ../.. {}).sops-install-secrets;
+      defaultText = literalExpression "(pkgs.callPackage ../.. {}).sops-install-secrets";
+      description = ''
+        sops-install-secrets package to use.
       '';
     };
 


### PR DESCRIPTION
I'd like to be able to override the sops-install-secrets package that is used in the module. I build the NixOS configuration for my Raspberry Pi's on my `x86_64-linux` system with the binfmt wrapper:

```
boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
```

Compiling sops-nix like this is slow, plus it also stalls for some unknown reason. With this PR I found the following workaround:

```
  outputs = { self, nixpkgs, sops-nix }: {
    nixosConfigurations = {
      neon = nixpkgs.lib.nixosSystem {
        system = "aarch64-linux";
        modules = [
          ./.
          { config._module.args = { inherit (self) modulesPath; }; }
          sops-nix.nixosModules.sops
          ({ pkgs, crossPkgs, ... }: {
            sops.package = crossPkgs.sops-install-secrets.override {
              inherit (pkgs) go;
            };
          })
        ];
        specialArgs = {
          crossPkgs = import nixpkgs {
            localSystem.system = "x86_64-linux";
            crossSystem.system = "aarch64-linux";
            overlays = [ sops-nix.overlay ];
          };
        };
      };
    };
  };
```

This will only cross compile sops-nix. It's fast and works for me but depends on being able to override the `sops-install-secrets` package in the sops module.