### PR TITLE
Fix lookup of users/groups in dry activation

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -455,7 +455,7 @@ func (app *appContext) validateSecret(secret *secret) error {
 	}
 	secret.mode = os.FileMode(mode)
 
-	if app.ignorePasswd {
+	if app.ignorePasswd || os.Getenv("NIXOS_ACTION") == "dry-activate" {
 		secret.owner = 0
 		secret.group = 0
 	} else if app.checkMode == Off {


### PR DESCRIPTION
This fails otherwise as the users snippet was not executed and the
user/group does not exist.

Closes #222
cc @slothofanarchy