### PR TITLE
Adding support for generating a Curve25119 based GPG key with sops-init-gpg-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,7 +764,34 @@ EOF
 # fingerprint: E4CA86768F176AEB6C01554153AF8D7F149613B1
 ```
 
-In this case, you must upload the GPG key directory `/tmp/newkey` onto the server.
+You can choose between a RSA GPG key (default, like in the example above) or a
+Curve25519 based one by adding `--keytype Curve25519` like so:
+
+```console
+$ nix-shell -p sops-init-gpg-key
+$ sops-init-gpg-key --hostname server01 --gpghome /tmp/newkey --keytype Curve25519
+You can use the following command to save it to a file:
+cat > server01.asc <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEY7dJExYJKwYBBAHaRw8BAQdAloRZFyqNh3nIDtyUQKaBSMJOtLkbNeg+4TPg
+BG5TduG0OG5peC1hLmhvbWUua3VldGVtZWllci5kZSA8cm9vdEBuaXgtYS5ob21l
+Lmt1ZXRlbWVpZXIuZGU+iJMEExYKADsWIQREE2hPxiNijOo+CSmrLxbGte+J7wUC
+Y7dJEwIbAwULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRCrLxbGte+J79LX
+AQDtLfQFDKm04ORIk28DrzTBbMTFQEW21dGBXk7ykBx4jQD/ZOnt1RPnB9mzMc8L
+wIS3oI8D9719DjoS9hrHnJ4xvge4OARjt0kTEgorBgEEAZdVAQUBAQdA0t1X35pN
+ic+etscIIkHjKUwrXhbTgWrARgXUuEMwwz8DAQgHiHgEGBYKACAWIQREE2hPxiNi
+jOo+CSmrLxbGte+J7wUCY7dJEwIbDAAKCRCrLxbGte+J7+0NAQCfj95TSyPEFKz3
+eLJ1aCA1bZZV/rkhHd+OwX1MFL3mKQD9GMPgvMzDIoofycDzMY2ttJgkRJfq+zOZ
+juXFQdUkMgY=
+=pf3V
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+fingerprint: 4413684FC623628CEA3E0929AB2F16C6B5EF89EF
+F0477297E369CD1D189DD901278D1535AB473B9E
+```
+
+In both cases, you must upload the GPG key directory `/tmp/newkey` onto the server.
 If you uploaded it to `/var/lib/sops` than your sops configuration will look like this:
 
 ```nix

--- a/pkgs/sops-init-gpg-key/sops-init-gpg-key
+++ b/pkgs/sops-init-gpg-key/sops-init-gpg-key
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail -o noclobber -o nounset
 
 OPTIONS=h
-LONGOPTS=help,gpghome:,hostname:
+LONGOPTS=help,gpghome:,hostname:,keytype:
 
 ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
 
@@ -17,9 +17,13 @@ eval set -- "$PARSED"
 
 FINAL_GNUPGHOME=/root/.gnupg
 HOSTNAME=$(hostname)
+KEYTYPE="RSA"
 
 usage() {
-    echo "$0: [--hostname hostname] [--gpghome home]"
+    echo "$0: [--hostname hostname] [--gpghome home] [--keytype keytype]"
+    echo
+    echo "  keytype: RSA (default) or Curve25519"
+    echo
 }
 
 while true; do
@@ -34,6 +38,10 @@ while true; do
       ;;
     --hostname)
       HOSTNAME=$2
+      shift 2
+      ;;
+    --keytype)
+      KEYTYPE=$2
       shift 2
       ;;
     --)
@@ -56,10 +64,28 @@ fi
 export GNUPGHOME=$(mktemp -d)
 trap "rm -rf $GNUPGHOME" EXIT
 
+
 cat > "$GNUPGHOME/key-template" <<EOF
 %no-protection
+EOF
+
+if [[ "$KEYTYPE" == "Curve25519" ]]; then
+  cat >> "$GNUPGHOME/key-template" <<EOF
+Key-Type: eddsa
+Key-Curve: Ed25519
+Key-Usage: sign
+Subkey-Type: ecdh
+Subkey-Curve: Curve25519
+Subkey-Usage: encrypt
+EOF
+else 
+  cat >> "$GNUPGHOME/key-template" <<EOF
 Key-Type: 1
 Key-Length: 2048
+EOF
+fi
+
+cat >> "$GNUPGHOME/key-template" <<EOF
 Name-Real: $HOSTNAME
 Name-Email: root@$HOSTNAME
 Expire-Date: 0

--- a/pkgs/sops-init-gpg-key/sops-init-gpg-key
+++ b/pkgs/sops-init-gpg-key/sops-init-gpg-key
@@ -78,7 +78,7 @@ Subkey-Type: ecdh
 Subkey-Curve: Curve25519
 Subkey-Usage: encrypt
 EOF
-else 
+elif [[ "$KEYTYPE" == "RSA" ]]; then
   cat >> "$GNUPGHOME/key-template" <<EOF
 Key-Type: 1
 Key-Length: 2048

--- a/pkgs/sops-init-gpg-key/sops-init-gpg-key
+++ b/pkgs/sops-init-gpg-key/sops-init-gpg-key
@@ -83,6 +83,9 @@ elif [[ "$KEYTYPE" == "RSA" ]]; then
 Key-Type: 1
 Key-Length: 2048
 EOF
+else
+  echo "unknown keytype '$KEYTYPE'"
+  exit 1
 fi
 
 cat >> "$GNUPGHOME/key-template" <<EOF


### PR DESCRIPTION
This add the option `--keytype` to `sops-init-gpg-key`. If it is missing, the default behaviour is kept and it generates a RSA GPG key - like before. If it is added like `--keytype Curve25119` (see README commit) it will generate a Curve25119 based key. Everything else works as before.