### PR TITLE
fix makeSetupHook deprecations

### DIFF
--- a/pkgs/sops-import-keys-hook/default.nix
+++ b/pkgs/sops-import-keys-hook/default.nix
@@ -1,8 +1,9 @@
 { stdenv, makeSetupHook, gnupg, sops, nix }:
 
 (makeSetupHook {
+  name = "sops-import-keys-hook";
   substitutions = {
     gpg = "${gnupg}/bin/gpg";
   };
-  deps = [ sops gnupg ];
+  propagatedBuildInputs = [ sops gnupg ];
 } ./sops-import-keys-hook.bash)

--- a/pkgs/sops-pgp-hook/default.nix
+++ b/pkgs/sops-pgp-hook/default.nix
@@ -1,8 +1,9 @@
 { stdenv, makeSetupHook, gnupg, sops, nix }:
 
 (makeSetupHook {
+  name = "sops-pgp-hook";
   substitutions = {
     gpg = "${gnupg}/bin/gpg";
   };
-  deps = [ sops gnupg ];
+  propagatedBuildInputs = [ sops gnupg ];
 } ./sops-pgp-hook.bash)


### PR DESCRIPTION
From [nixpkgs](https://github.com/NixOS/nixpkgs/blob/c333779d748a996a9a305b3d1fcf6b12b51564ed/pkgs/build-support/trivial-builders.nix#L598):

> calling makeSetupHook without passing a name is deprecated.

> 'deps' argument to makeSetupHook is deprecated and will be removed in release 23.11., Please use propagatedBuildInputs instead.