### PR TITLE
HM: make `secretsMountPoint` and `symlinkPath` configurable

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -25,7 +25,7 @@ let
 
       path = lib.mkOption {
         type = lib.types.str;
-        default = "%r/secrets/${name}";
+        default = "${cfg.defaultSymlinkPath}/${name}";
         description = ''
           Path where secrets are symlinked to.
           If the default is kept no other symlink is created.
@@ -66,8 +66,8 @@ let
     name = "manifest${suffix}.json";
     text = builtins.toJSON {
       secrets = builtins.attrValues secrets;
-      secretsMountPoint = "%r/secrets.d";
-      symlinkPath = "%r/secrets";
+      secretsMountPoint = cfg.defaultSecretsMountPoint;
+      symlinkPath = cfg.defaultSymlinkPath;
       keepGenerations = cfg.keepGenerations;
       gnupgHome = cfg.gnupg.home;
       sshKeyPaths = cfg.gnupg.sshKeyPaths;
@@ -130,6 +130,23 @@ in {
       description = ''
         Check all sops files at evaluation time.
         This requires sops files to be added to the nix store.
+      '';
+    };
+
+    defaultSymlinkPath = lib.mkOption {
+      type = lib.types.str;
+      default = "%r/secrets";
+      description = ''
+        Default place where the latest generation of decrypt secrets
+        can be found.
+      '';
+    };
+
+    defaultSecretsMountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "%r/secrets.d";
+      description = ''
+        Default place where generations of decrypted secrets are stored.
       '';
     };
 


### PR DESCRIPTION
Related: https://github.com/Mic92/sops-nix/issues/284

The `%r` specifier used in the home-manager module has been deprecated by systemd for quite a while, and doesn't work smoothly with `AssertPath...` directives in my experiments.

This PR adds two options `defaultSymlinkPath` and `defaultSecretsMountPoint` to make their corresponding manifest field configurable, but their defaults remain intact.

Tested on my laptop setup.