### PR TITLE
HM: make `secretsMountPoint` and `symlinkPath` configurable

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -25,7 +25,7 @@ let
 
       path = lib.mkOption {
         type = lib.types.str;
-        default = "%r/secrets/${name}";
+        default = "${cfg.defaultSymlinkPath}/${name}";
         description = ''
           Path where secrets are symlinked to.
           If the default is kept no other symlink is created.
@@ -66,8 +66,8 @@ let
     name = "manifest${suffix}.json";
     text = builtins.toJSON {
       secrets = builtins.attrValues secrets;
-      secretsMountPoint = "%r/secrets.d";
-      symlinkPath = "%r/secrets";
+      secretsMountPoint = cfg.defaultSecretsMountPoint;
+      symlinkPath = cfg.defaultSymlinkPath;
       keepGenerations = cfg.keepGenerations;
       gnupgHome = cfg.gnupg.home;
       sshKeyPaths = cfg.gnupg.sshKeyPaths;
@@ -130,6 +130,23 @@ in {
       description = ''
         Check all sops files at evaluation time.
         This requires sops files to be added to the nix store.
+      '';
+    };
+
+    defaultSymlinkPath = lib.mkOption {
+      type = lib.types.str;
+      default = "%r/secrets";
+      description = ''
+        Default place where the latest generation of decrypt secrets
+        can be found.
+      '';
+    };
+
+    defaultSecretsMountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "%r/secrets.d";
+      description = ''
+        Default place where generations of decrypted secrets are stored.
       '';
     };
 


### PR DESCRIPTION
This is a re-submit of #305.  Author has given permission to re-submit in the named PR. 

See my re-submit as approval of the original PR, as i did literally change nothing.

For integration someone need to set the following in their home config to mimic the same logic as the standalone.

```nix
{
  self,
  config,
  lib,
  pkgs,
  ...
}: let
  userName = "myUserName";
  hmConfig = config.home-manager.users.${userName};
  user = config.users.users.${userName};
in {
  home-manager.users.${userName} = {
    sops = {
      # or some other source for the decryption key
      age.keyFile = "${hmConfig.xdg.configHome}/sops/age/keys.txt";
      # or which file contains the encrypted secrets
      defaultSopsFile = ./secrets.yaml;
      defaultSymlinkPath = "/run/user/${toString user.uid}/secrets";
      defaultSecretsMountPoint = "/run/user/${toString user.uid}/secrets.d";
      secrets = {
        aSecret = {path = "${hmConfig.xdg.configHome}/aApplication/targetOfSecretFile";};
      };
    };
  };
}
```
the aboves code i just a "generalized" version of writting attics config file to the xdg config folder, that can be found [here (WIP)](https://github.com/Shawn8901/nix-configuration/blob/fffa529f5a598b58d4d751242de9501e4af1e47d/machines/zenbook/home.nix#L14).