### PR TITLE
templates: Add descriptions and use singleLineStr

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -9,17 +9,19 @@ let
 in {
   options.sops = {
     templates = mkOption {
+      description = "Templates for secret files";
       type = attrsOf (submodule ({ config, ... }: {
         options = {
           name = mkOption {
-            type = str;
+            type = singleLineStr;
             default = config._module.args.name;
             description = ''
               Name of the file used in /run/secrets-rendered
             '';
           };
           path = mkOption {
-            type = str;
+            description = "Path where the rendered file will be placed";
+            type = singleLineStr;
             default = "/run/secrets-rendered/${config.name}";
           };
           content = mkOption {
@@ -30,21 +32,21 @@ in {
             '';
           };
           mode = mkOption {
-            type = str;
+            type = singleLineStr;
             default = "0400";
             description = ''
               Permissions mode of the rendered secret file in octal.
             '';
           };
           owner = mkOption {
-            type = str;
+            type = singleLineStr;
             default = "root";
             description = ''
               User of the file.
             '';
           };
           group = mkOption {
-            type = str;
+            type = singleLineStr;
             default = users.${config.owner}.group;
             description = ''
               Group of the file.


### PR DESCRIPTION
This is mainly for fixing this in my systems:
```
error: option sops.templates has no description
error: option sops.templates.<name>.path has no description
Treating warnings as errors. Set documentation.nixos.options.warningsAreErrors to false to ignore these warnings.
```