### PR TITLE
modules/sops/templates: declare `defaultText` for `sops.templates.<name>.group`

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -48,6 +48,7 @@ in {
           group = mkOption {
             type = singleLineStr;
             default = users.${config.owner}.group;
+            defaultText = ''config.users.users.''${cfg.owner}.group'';
             description = ''
               Group of the file.
             '';


### PR DESCRIPTION
When using `documentation.nixos.includeAllModules = true;` this fails for me with

    error: attribute 'users' missing

           at /nix/store/30jax2y4q3d1xyf8ha3cwilw3kdz4pn8-source/modules/sops/templates/default.nix:8:11:

                7|   secretsForUsers = lib.filterAttrs (_: v: v.neededForUsers) cfg.secrets;
                8|   users = config.users.users;
                 |           ^
                9| in {
    (use '--show-trace' to show detailed location information)

Not depending on `config` when building the manual fixes the issue.

cc @mic92 @Ninlives 