### PR TITLE
Allow nested secrets in secrets.json

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -239,13 +240,13 @@ func recurseSecretKey(keys map[string]interface{}, wantedKey string) (string, er
 		if !ok {
 			return "", fmt.Errorf("The key '%s' cannot be found", keyUntilNow)
 		}
-		valWithWrongType, ok := val.(map[interface{}]interface{})
+		valWithWrongType, ok := val.(map[string]interface{})
 		if !ok {
-			return "", fmt.Errorf("Key '%s' does not refer to a dictionary", keyUntilNow)
+			return "", fmt.Errorf("Expected key '%s' to refer to a dictionary, but it is a '%s' instead", keyUntilNow, reflect.TypeOf(val).Elem())
 		}
 		currentData = make(map[string]interface{})
 		for key, value := range valWithWrongType {
-			currentData[key.(string)] = value
+			currentData[key] = value
 		}
 	}
 


### PR DESCRIPTION
Prior to this change, if `secrets.json` had nested secrets ([example](https://github.com/srid/nixos-config/blob/15d848f475efc505107d3faa78c9ab2125e403cd/secrets.json#L8)) we would see this error:

```
sops-install-secrets: Manifest is not valid: secret jenkins-nix-ci/cachix-auth-token/description in /nix/store/wxm763za3rbrpiijfbgss9g5ll0sd29z-secrets.json is not valid: Key 'jenkins-nix-ci' does not refer to a dictionary
```

The reason happens to be that introspecting the map key to be `interface` fails, when it is in fact a string. This PR makes it so that we always expect the key to be a string (what else could it be?). It also improves the error message, by telling the user what the actual value type is.