### PR TITLE
modules/sops: fix description of `useTmpfs`

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -246,7 +246,7 @@ in {
     useTmpfs = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mkDoc ''
+      description = lib.mdDoc ''
         Use tmpfs in place of ramfs for secrets storage.
 
         *WARNING*


### PR DESCRIPTION
It's supposed to be mdDoc rather than mkDoc.

cc @Mic92 