### PR TITLE
don't substitute binaries

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -90,11 +90,12 @@ in {
                 tpl = config.sops.templates.${name};
                 substitute = pkgs.writers.writePython3 "substitute" { }
                   (readFile ./subs.py);
-                subst-pairs = pkgs.writeText "pairs" (concatMapStringsSep "\n"
+                subst-pairs = pkgs.writeText "pairs" (flip (concatMapStringsSep "\n")
+                  (attrNames (filterAttrs (n: v: v ? format && v.format != "binary") config.sops.secrets))
                   (name:
                     "${toString config.sops.placeholder.${name}} ${
                       config.sops.secrets.${name}.path
-                    }") (attrNames config.sops.secrets));
+                    }"));
               in ''
                 mkdir -p "${dirOf tpl.path}"
                 (umask 077; ${substitute} ${tpl.file} ${subst-pairs} > ${tpl.path})


### PR DESCRIPTION
currently mixing templates and binary keys in the same configuration b0rks evaluation since `f.read()` speaks utf-8, it also doesn't make sense to template binaries which are not string encoded