### PR TITLE
Remove confusing and redundant left over text

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ $ nix-shell -p gnupg -p ssh-to-pgp --run "ssh-to-pgp -private-key -i /tmp/id_rsa
 $ rm /tmp/id_rsa
 ```
 
-You can also use an existing SSH Ed25519 key as an `age` key; to do so, see the following.
-
 <details>
 <summary> How to find the public key of an `age` key </summary>
 


### PR DESCRIPTION
This line is left over from a set of instructions that were previously incorporated into an early console example under "you can generate yourself a key:" above.