### PR TITLE
add nix config snippet to restart sops-nix service

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,15 @@ The secrets are decrypted in a systemd user service called `sops-nix`, so other 
 }
 ```
 
+As home-manager does not restart the `sops-nix` unit automatically instruct home-manager to do so:
+```nix
+{
+  home.activation.setupEtc = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    /run/current-system/sw/bin/systemctl start --user sops-nix
+  '';
+}
+```
+
 ## Use with GPG instead of SSH keys
 
 If you prefer having a separate GPG key, sops-nix also comes with a helper tool, `sops-init-gpg-key`:


### PR DESCRIPTION
As home-manager does not restart the `sops-nix` unit automatically a snippet to instruct home-manager to do so is added.

Home-manager could be instructed to restart the user service from the sops-nix home-manager module instead. Usually home-manager restarts units which changed. Since the sops-nix unit does not change when secrets change this does not trigger automatically.

There are two options:
- let sops-nix home-manager module compute a chained hash over all secrets and place it inside the unit file, so it changes every time the secrets change
- use X-SwitchMethod and X-Restart-Triggers See nix-community/home-manager#3865