### PR TITLE
modules/sops/templates: Support custom files as secret templates

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -56,8 +56,10 @@ in {
           file = mkOption {
             type = types.path;
             default = pkgs.writeText config.name config.content;
-            visible = false;
-            readOnly = true;
+            defaultText = ''pkgs.writeText config.name config.content'';
+            description = ''
+              File used as the template.
+            '';
           };
         };
       }));


### PR DESCRIPTION
This exposes the `file` option, which can be used with `pkgs.formats` to write additional configuration formats.

Without this option exposed, it's not possible to write configuration file formats like YAML or TOML that require a package build to generate.