### PR TITLE
Only read referenced secret on template rendering

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -90,12 +90,11 @@ in {
                 tpl = config.sops.templates.${name};
                 substitute = pkgs.writers.writePython3 "substitute" { }
                   (readFile ./subs.py);
-                subst-pairs = pkgs.writeText "pairs" (flip (concatMapStringsSep "\n")
-                  (attrNames (filterAttrs (n: v: v ? format && v.format != "binary") config.sops.secrets))
+                subst-pairs = pkgs.writeText "pairs" (concatMapStringsSep "\n"
                   (name:
                     "${toString config.sops.placeholder.${name}} ${
                       config.sops.secrets.${name}.path
-                    }"));
+                    }") (attrNames config.sops.secrets));
               in ''
                 mkdir -p "${dirOf tpl.path}"
                 (umask 077; ${substitute} ${tpl.file} ${subst-pairs} > ${tpl.path})

--- a/modules/sops/templates/subs.py
+++ b/modules/sops/templates/subs.py
@@ -10,8 +10,9 @@ def substitute(target: str, subst: str) -> str:
 
     for pair in subst_pairs:
         placeholder, path = pair.split()
-        with open(path) as f:
-            content = content.replace(placeholder, f.read())
+        if placeholder in content:
+            with open(path) as f:
+                content = content.replace(placeholder, f.read())
 
     return content
 


### PR DESCRIPTION
While we can't use non-utf8 data in template, it's not a good idea to use `config.sops.secrets.<name>.format` to determine if a secret is actually utf8 text, as yaml secrets can have embedded binary data (#496) and "binary" secrets can actually contain utf8 text (#439).

With this patch, we only read secret file when the corresponding placeholder actually occurs in template content. This way, we no longer need to try to exclude binary files from the replacement list, but rely on users to only reference text secret in templates.