### PR TITLE
Update README.md with a note for Impermanence Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,9 @@ $y$j9T$WFoiErKnEnMcGq0ruQK4K.$4nJAY3LBeBsZBTYSkdTOejKU6KlDmhnfUV3Ll1K/1b.
 }
 ```
 
+**Note:** If you are using Impermanence, you must set `sops.age.keyFile` to a keyfile inside your persist directory or it will not exist at boot time. 
+For example: `/nix/persist/var/lib/sops-nix/key.txt`
+
 ## Different file formats
 
 At the moment we support the following file formats: YAML, JSON, INI, dotenv and binary.

--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ $y$j9T$WFoiErKnEnMcGq0ruQK4K.$4nJAY3LBeBsZBTYSkdTOejKU6KlDmhnfUV3Ll1K/1b.
 
 **Note:** If you are using Impermanence, you must set `sops.age.keyFile` to a keyfile inside your persist directory or it will not exist at boot time. 
 For example: `/nix/persist/var/lib/sops-nix/key.txt`
+Similarly if ssh host keys are used instead, they also need to be placed inside the persisted storage.
 
 ## Different file formats
 


### PR DESCRIPTION
A note was added to the "Setting a user's password" part of the Read-me to help people avoid a serious pitfall. Warns Impermanence Users to link to they keyfile through there persist instead of the normal way.