### PR TITLE
remove all uses of lib.mdDoc

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -218,7 +218,7 @@ in {
     useTmpfs = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Use tmpfs in place of ramfs for secrets storage.
 
         *WARNING*


### PR DESCRIPTION
As of https://github.com/NixOS/nixpkgs/pull/303841/ `lib.mdDoc` is no longer supported.