### PR TITLE
home-manager: Include home.activation-script for linux similar to macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,15 +804,6 @@ The secrets are decrypted in a systemd user service called `sops-nix`, so other 
 }
 ```
 
-As home-manager does not restart the `sops-nix` unit automatically instruct home-manager to do so:
-```nix
-{
-  home.activation.setupEtc = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    /run/current-system/sw/bin/systemctl start --user sops-nix
-  '';
-}
-```
-
 ## Use with GPG instead of SSH keys
 
 If you prefer having a separate GPG key, sops-nix also comes with a helper tool, `sops-init-gpg-key`:

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -256,15 +256,29 @@ in {
       };
     };
 
-    # darwin: [re]load secrets on home-manager activation
-    home.activation = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-      sops-nix = let
+    # [re]load secrets on home-manager activation
+    home.activation = let 
+      darwin = let
         domain-target = "gui/$(id -u ${config.home.username})";
       in ''
         /bin/launchctl bootout ${domain-target}/org.nix-community.home.sops-nix && true
         /bin/launchctl bootstrap ${domain-target} ${config.home.homeDirectory}/Library/LaunchAgents/org.nix-community.home.sops-nix.plist
       '';
-    };
 
+      linux = let systemctl = config.systemd.user.systemctlPath; in ''
+        systemdStatus=$(${systemctl} --user is-system-running 2>&1 || true)
+
+        if [[ $systemdStatus == 'running' ]]; then
+          ${config.systemd.user.systemctlPath} restart --user sops-nix
+        else
+          echo "User systemd daemon not running. Probably executed on boot where no manual start/reload is needed."
+        fi
+
+        unset systemdStatus
+      '';
+    
+    in {
+      sops-nix = if pkgs.stdenv.isLinux then linux else darwin;
+    };
   };
 }


### PR DESCRIPTION
Split out from https://github.com/Mic92/sops-nix/pull/530

```
Apr 16 16:01:22 bsPF1201 systemd[1]: Starting Home Manager environment for sebtm...
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Starting Home Manager activation
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating checkFilesChanged
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating checkLinkTargets
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating writeBoundary
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating createGpgHomedir
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating migrateGhAccounts
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating linkGeneration
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Creating profile generation 1
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Creating home file links in /home/sebtm
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[1921]: Activating batCache
Apr 16 16:01:22 bsPF1201 hm-activate-sebtm[2203]: No themes were found in '/home/sebtm/.config/bat/themes', using the default set
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2203]: No syntaxes were found in '/home/sebtm/.config/bat/syntaxes', using the default set.
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2203]: Writing theme set to /home/sebtm/.cache/bat/themes.bin ... okay
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2203]: Writing syntax set to /home/sebtm/.cache/bat/syntaxes.bin ... okay
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2203]: Writing metadata to folder /home/sebtm/.cache/bat ... okay
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: Activating installPackages
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: Activating dconfSettings
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2267]: dbus-daemon[2267]: [session uid=1000 pid=2267] Activating service name='ca.desrt.dconf' requested by ':1.0' (uid=1000 pid=2268 comm="/nix/store/ajbcv0smqbswir3zjr66qzpzqyzbfwgv-dconf-" label="kernel")
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[2267]: dbus-daemon[2267]: [session uid=1000 pid=2267] Successfully activated service 'ca.desrt.dconf'
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: Activating onFilesChange
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: Activating reloadSystemd
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: User systemd daemon not running. Skipping reload.
Apr 16 16:01:23 bsPF1201 hm-activate-sebtm[1921]: Activating sops-nix
Apr 16 16:01:23 bsPF1201 systemctl[2285]: Failed to connect to bus: No medium found
Apr 16 16:01:23 bsPF1201 systemd[1]: home-manager-sebtm.service: Main process exited, code=exited, status=1/FAILURE
Apr 16 16:01:23 bsPF1201 systemd[1]: home-manager-sebtm.service: Failed with result 'exit-code'.
Apr 16 16:01:23 bsPF1201 systemd[1]: Failed to start Home Manager environment for sebtm.
```

From my POV the proposed code was not working as home-manager got started on boot some-when and failed to start sops-nix as systemd for the user is not running.

This solution is inspired from the approach here: https://github.com/nix-community/home-manager/blob/master/modules/systemd.nix#L338