### PR TITLE
fix: sops-nix systemd unit failing to start

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -247,6 +247,7 @@ in {
       };
       Service = {
         Type = "oneshot";
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${lib.strings.removeSuffix (builtins.baseNameOf config.sops.defaultSymlinkPath) config.sops.defaultSymlinkPath}";
         ExecStart = script;
       };
       Install.WantedBy = if cfg.gnupg.home != null then [ "graphical-session-pre.target" ] else [ "default.target" ];


### PR DESCRIPTION
This pull request adds `ExecStartPre` to sops-nix systemd unit to ensure the `defaultSecretsMountPoint` directory is created.

- As discussed here: https://github.com/Mic92/sops-nix/pull/530#issuecomment-2063309938

Fixes #535