### PR TITLE
Use minimal gnupg

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -231,13 +231,13 @@ in {
 
         *WARNING*
         Enabling this option has the potential to write secrets to disk unencrypted if the tmpfs volume is written to swap. Do not use unless absolutely necessary.
-        
+
         When using a swap file or device, consider enabling swap encryption by setting the `randomEncryption.enable` option
-        
+
         ```
         swapDevices = [{
           device = "/dev/sdXY";
-          randomEncryption.enable = true; 
+          randomEncryption.enable = true;
         }];
         ```
       '';
@@ -320,7 +320,7 @@ in {
         }]) cfg.secrets)
       );
 
-      sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != []) (lib.mkDefault "${pkgs.gnupg}/bin/gpg");
+      sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != []) (lib.mkDefault (lib.getExe (pkgs.gnupg.override { enableMinimal = true; })));
 
       # When using sysusers we no longer be started as an activation script because those are started in initrd while sysusers is started later.
       systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && sysusersEnabled) {


### PR DESCRIPTION
The closure size of the minimal gnupg is significant smaller.

                                                        normal gnupg                                              minimal gnupg
 ➜ nix path-info --size --closure-size --human-readable /nix/store/5kk1414f5iadlz9b7vnbg5dlk6icryjl-gnupg-2.4.5/ /nix/store/xp9bd1qyw5bdhshxmd1bdlhbi5hwdxwy-gnupg-2.4.5
/nix/store/5kk1414f5iadlz9b7vnbg5dlk6icryjl-gnupg-2.4.5   12.8M  133.5M
/nix/store/xp9bd1qyw5bdhshxmd1bdlhbi5hwdxwy-gnupg-2.4.5    1.2M   34.4M