### PR TITLE
sops-install-secrets: add mount options for darwin

### DIFF
--- a/pkgs/sops-install-secrets/darwin.go
+++ b/pkgs/sops-install-secrets/darwin.go
@@ -77,7 +77,7 @@ func MountSecretFs(mountpoint string, keysGID int, _useTmpfs bool, userMode bool
 	log.Printf("hdiutil attach ret %v. out: %s", err, diskpath)
 
 	// format as hfs
-	out, err = exec.Command("newfs_hfs", diskpath).Output()
+	out, err = exec.Command("newfs_hfs", "-s", diskpath).Output()
 	log.Printf("newfs_hfs ret %v. out: %s", err, out)
 
 	// "posix" mount takes `struct hfs_mount_args` which we dont have bindings for at hand.

--- a/pkgs/sops-install-secrets/darwin.go
+++ b/pkgs/sops-install-secrets/darwin.go
@@ -84,7 +84,7 @@ func MountSecretFs(mountpoint string, keysGID int, _useTmpfs bool, userMode bool
 	// See https://stackoverflow.com/a/49048846/4108673
 	// err = unix.Mount("hfs", mountpoint, unix.MNT_NOEXEC|unix.MNT_NODEV, mount_args)
 	// Instead we call:
-	out, err = exec.Command("mount", "-t", "hfs", diskpath, mountpoint).Output()
+	out, err = exec.Command("mount", "-t", "hfs", "-o", "nobrowse,nodev,nosuid,-m=0751", diskpath, mountpoint).Output()
 	log.Printf("mount ret %v. out: %s", err, out)
 
 	// There is no documented way to check for memfs mountpoint. Thus we place a file.


### PR DESCRIPTION
On macOS, secretfs sometimes appears on the desktop, which is a bit troublesome for me. Mounting with the `nobrowse` option should avoid this issue.

The other mounting options were derived from already commented code. If there are any issues, please let me know.