### PR TITLE
Allow sops-nix to be restarted when systemd is degraded

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -278,7 +278,7 @@ in {
       linux = let systemctl = config.systemd.user.systemctlPath; in ''
         systemdStatus=$(${systemctl} --user is-system-running 2>&1 || true)
 
-        if [[ $systemdStatus == 'running' ]]; then
+        if [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
           ${systemctl} restart --user sops-nix
         else
           echo "User systemd daemon not running. Probably executed on boot where no manual start/reload is needed."


### PR DESCRIPTION
When even a single unit is failed, `systemd is-system-running` will return `degraded`.  This will prevent sops-nix from being restarted, and will make is seem like sops-nixs under home-manager isn't working.

According to https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#is-system-running, `degraded` means systemd is in a running state (not starting, or stopping), but that there's one or more failed units.

Inspired by https://github.com/nix-community/home-manager/blob/ffe2d07e771580a005e675108212597e5b367d2d/modules/systemd.nix#L358 I've added `degraded` as a state in which the activation script will restart `sops-nix`.

This will help sops-nix under home-manager behave better when there are other, unrelated unit failures on the system.

