### PR TITLE
Allow to set uid and gid instead of owner and group.

### DIFF
--- a/modules/sops/secrets-for-users/default.nix
+++ b/modules/sops/secrets-for-users/default.nix
@@ -43,7 +43,7 @@ in
   };
 
   assertions = [{
-    assertion = (lib.filterAttrs (_: v: v.owner != "root" || v.group != "root") secretsForUsers) == { };
+    assertion = (lib.filterAttrs (_: v: (v.uid != 0 && v.owner != "root") || (v.gid != 0 && v.group != "root")) secretsForUsers) == { };
     message = "neededForUsers cannot be used for secrets that are not root-owned";
   } {
     assertion = secretsForUsers != { } && sysusersEnabled -> config.users.mutableUsers;

--- a/pkgs/sops-install-secrets/main_test.go
+++ b/pkgs/sops-install-secrets/main_test.go
@@ -98,12 +98,14 @@ func testGPG(t *testing.T) {
 		}
 	}()
 
+	nobody := "nobody"
+	nogroup := "nogroup"
 	// should create a symlink
 	yamlSecret := secret{
 		Name:         "test",
 		Key:          "test_key",
-		Owner:        "nobody",
-		Group:        "nogroup",
+		Owner:        &nobody,
+		Group:        &nogroup,
 		SopsFile:     path.Join(assets, "secrets.yaml"),
 		Path:         path.Join(testdir.path, "test-target"),
 		Mode:         "0400",
@@ -112,12 +114,13 @@ func testGPG(t *testing.T) {
 	}
 
 	var jsonSecret, binarySecret, dotenvSecret, iniSecret secret
+	root := "root"
 	// should not create a symlink
 	jsonSecret = yamlSecret
 	jsonSecret.Name = "test2"
-	jsonSecret.Owner = "root"
+	jsonSecret.Owner = &root
 	jsonSecret.Format = "json"
-	jsonSecret.Group = "root"
+	jsonSecret.Group = &root
 	jsonSecret.SopsFile = path.Join(assets, "secrets.json")
 	jsonSecret.Path = path.Join(testdir.secretsPath, "test2")
 	jsonSecret.Mode = "0700"
@@ -130,16 +133,16 @@ func testGPG(t *testing.T) {
 
 	dotenvSecret = yamlSecret
 	dotenvSecret.Name = "test4"
-	dotenvSecret.Owner = "root"
-	dotenvSecret.Group = "root"
+	dotenvSecret.Owner = &root
+	dotenvSecret.Group = &root
 	dotenvSecret.Format = "dotenv"
 	dotenvSecret.SopsFile = path.Join(assets, "secrets.env")
 	dotenvSecret.Path = path.Join(testdir.secretsPath, "test4")
 
 	iniSecret = yamlSecret
 	iniSecret.Name = "test5"
-	iniSecret.Owner = "root"
-	iniSecret.Group = "root"
+	iniSecret.Owner = &root
+	iniSecret.Group = &root
 	iniSecret.Format = "ini"
 	iniSecret.SopsFile = path.Join(assets, "secrets.ini")
 	iniSecret.Path = path.Join(testdir.secretsPath, "test5")
@@ -214,11 +217,13 @@ func testSSHKey(t *testing.T) {
 	ok(t, err)
 	file.Close()
 
+	nobody := "nobody"
+	nogroup := "nogroup"
 	s := secret{
 		Name:         "test",
 		Key:          "test_key",
-		Owner:        "nobody",
-		Group:        "nogroup",
+		Owner:        &nobody,
+		Group:        &nogroup,
 		SopsFile:     path.Join(assets, "secrets.yaml"),
 		Path:         target,
 		Mode:         "0400",
@@ -247,11 +252,13 @@ func TestAge(t *testing.T) {
 	ok(t, err)
 	file.Close()
 
+	nobody := "nobody"
+	nogroup := "nogroup"
 	s := secret{
 		Name:         "test",
 		Key:          "test_key",
-		Owner:        "nobody",
-		Group:        "nogroup",
+		Owner:        &nobody,
+		Group:        &nogroup,
 		SopsFile:     path.Join(assets, "secrets.yaml"),
 		Path:         target,
 		Mode:         "0400",
@@ -280,11 +287,13 @@ func TestAgeWithSSH(t *testing.T) {
 	ok(t, err)
 	file.Close()
 
+	nobody := "nobody"
+	nogroup := "nogroup"
 	s := secret{
 		Name:         "test",
 		Key:          "test_key",
-		Owner:        "nobody",
-		Group:        "nogroup",
+		Owner:        &nobody,
+		Group:        &nogroup,
 		SopsFile:     path.Join(assets, "secrets.yaml"),
 		Path:         target,
 		Mode:         "0400",
@@ -314,11 +323,13 @@ func TestValidateManifest(t *testing.T) {
 	testdir := newTestDir(t)
 	defer testdir.Remove()
 
+	nobody := "nobody"
+	nogroup := "nogroup"
 	s := secret{
 		Name:         "test",
 		Key:          "test_key",
-		Owner:        "nobody",
-		Group:        "nogroup",
+		Owner:        &nobody,
+		Group:        &nogroup,
 		SopsFile:     path.Join(assets, "secrets.yaml"),
 		Path:         path.Join(testdir.path, "test-target"),
 		Mode:         "0400",


### PR DESCRIPTION
https://github.com/Mic92/sops-nix/issues/514

Allow to set uid and gid instead of owner and group. No checks will be performed when uid and gid are set.

```
sops.secrets = {
  sslCertificate = {
    sopsFile = ./secrets.yaml;
    owner = "";
    group = "";
    uid = config.containers."nginx".config.users.users."nginx".uid;
    gid = config.containers."nginx".config.users.groups."nginx".gid;
  };
  sslCertificateKey = {
    sopsFile = ./secrets.yaml;
    owner = "";
    group = "";
    uid = config.containers."nginx".config.users.users."nginx".uid;
    gid = config.containers."nginx".config.users.groups."nginx".gid;
  };
};
```