### PR TITLE
fix missing lib in mkOption

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -132,7 +132,7 @@ in {
       '';
     };
 
-    defaultSopsKey = mkOption {
+    defaultSopsKey = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
       description = ''


### PR DESCRIPTION
Adding lib to mkOption for defaultSopsKey. 

This should fix https://github.com/Mic92/sops-nix/issues/650