### PR TITLE
Improve activation messages about rendered templates

### DIFF
--- a/modules/sops/templates/default.nix
+++ b/modules/sops/templates/default.nix
@@ -24,6 +24,7 @@ in {
           path = mkOption {
             description = "Path where the rendered file will be placed";
             type = types.singleLineStr;
+            # Keep this in sync with `RenderedSubdir` in `pkgs/sops-install-secrets/main.go`
             default = "/run/secrets/rendered/${config.name}";
           };
           content = mkOption {

--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -984,12 +985,15 @@ func handleModifications(isDry bool, logcfg loggingConfig, symlinkPath string, s
 			} else {
 				fmt.Printf("%s secret%s: ", regularPrefix, s)
 			}
-			comma := ""
-			for name := range changed {
-				fmt.Printf("%s%s", comma, name)
-				comma = ", "
+
+			// Sort the output for deterministic behavior.
+			keys := make([]string, 0, len(changed))
+			for key := range changed {
+				keys = append(keys, key)
 			}
-			fmt.Println()
+			sort.Strings(keys)
+
+			fmt.Println(strings.Join(keys, ", "))
 		}
 	}
 	outputChanged(newSecrets, "adding", "would add")

--- a/pkgs/sops-install-secrets/nixos-test.nix
+++ b/pkgs/sops-install-secrets/nixos-test.nix
@@ -421,6 +421,7 @@ in {
         assertOutput(
           out,
           "adding secret: test_key",
+          "adding rendered secret: test_template",
         )
 
         machine.succeed(": > /run/secrets/test_key")
@@ -429,8 +430,7 @@ in {
         assertOutput(
           out,
           "modifying secret: test_key",
-          # This is wrong. TODO: fix https://github.com/Mic92/sops-nix/issues/652
-          "removing secret: rendered/test_template",
+          "modifying rendered secret: test_template",
         )
 
         machine.succeed(": > /run/secrets/another_key")
@@ -438,8 +438,8 @@ in {
         out = machine.succeed("/run/current-system/bin/switch-to-configuration test")
         assertOutput(
           out,
-          # This is wrong. TODO: fix https://github.com/Mic92/sops-nix/issues/652
-          "removing secrets: another_key, rendered/another_template, rendered/test_template",
+          "removing secret: another_key",
+          "removing rendered secret: another_template",
         )
 
       with subtest("dry activation"):
@@ -451,8 +451,9 @@ in {
         assertOutput(
           out,
           "would add secret: test_key",
-          # This is wrong. TODO: fix https://github.com/Mic92/sops-nix/issues/652
-          "would remove secrets: another_key, rendered/another_template",
+          "would remove secret: another_key",
+          "would add rendered secret: test_template",
+          "would remove rendered secret: another_template",
         )
 
         # Verify that we did not actually activate the new configuration.
@@ -477,8 +478,6 @@ in {
         assertOutput(
           out,
           "would modify secret: test_key",
-          # This is wrong. TODO: fix https://github.com/Mic92/sops-nix/issues/652
-          "would remove secret: rendered/test_template",
         )
         machine.succeed("[ $(cat /run/secrets/test_key | wc -c) = 0 ]")
 


### PR DESCRIPTION
This PR contains 2 commits, I suggest reading them independently:

1. The first commit adds a test that demonstrates <https://github.com/Mic92/sops-nix/issues/652>. It doesn't actually fix the bug.
2. The second commit fixes https://github.com/Mic92/sops-nix/issues/652