### PR TITLE
Demonstration of how system activation fails if the template path is not "external"

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -354,7 +354,7 @@ in {
 
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != []) (lib.mkDefault "${pkgs.gnupg}/bin/gpg");
 
-      # When using sysusers we no longer be started as an activation script because those are started in initrd while sysusers is started later.
+      # When using sysusers we no longer are started as an activation script because those are started in initrd while sysusers is started later.
       systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && useSystemdActivation) {
         wantedBy = [  "sysinit.target" ];
         after = [ "systemd-sysusers.service" ];


### PR DESCRIPTION
This demonstrates one way of reproducing
https://github.com/Mic92/sops-nix/issues/659. There may be others: I think you could achieve the same thing with a regular secret rather than a template.

Here's how this fails:

    $ nix build .#checks.x86_64-linux.template-path-not-external -L
    ...
    vm-test-run-sops-template-path-not-external> machine: must succeed: /run/current-system/bin/switch-to-configuration test
    vm-test-run-sops-template-path-not-external> machine # [   11.028130] nixos[949]: switching to system configuration /nix/store/0jbh5rys5x1br66s4n777jq8ny2bq9nb-nixos-system-machine-test
    vm-test-run-sops-template-path-not-external> machine # [   11.029653] systemd[1]: Stopped target Local File Systems.
    vm-test-run-sops-template-path-not-external> machine # [   11.031619] systemd[1]: Stopped target Remote File Systems.
    vm-test-run-sops-template-path-not-external> machine # activating the configuration...
    vm-test-run-sops-template-path-not-external> machine # /nix/store/8788mz0w701ff12zpsgnbm7nzsfy290k-sops-install-secrets-0.0.1/bin/sops-install-secrets: failed to prepare new secrets directory: cannot access /run/secrets: readlink /run/secrets: invalid argument
    vm-test-run-sops-template-path-not-external> machine # Failed to run activate script
    ...

The only fix I can think of is to check if the chosen path is inside of `/run/secrets` and reject it if it is (of course allowing for the default value for these paths, which actually *is* inside of `/run/secrets`).