### PR TITLE
move nixpkgs-stable to private flake inputs

### DIFF
--- a/.github/workflows/upgrade-flakes.yml
+++ b/.github/workflows/upgrade-flakes.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  '51 2 * * 0'
+
+permissions:
+  pull-requests: write
+
 jobs:
   createPullRequest:
     runs-on: ubuntu-latest
@@ -14,9 +18,12 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v24
-        with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
-          pr-labels: |
-            merge-queue
+      - name: Update flakes
+        run: |
+           nix flake update
+           pushd dev/private
+           nix flake update
+           popd
+           nix run .#update-dev-private-narHash
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7

--- a/dev/private.narHash
+++ b/dev/private.narHash
@@ -1,0 +1,1 @@
+sha256-qF9EiqHqJARLtA+ZABXa2mstgbza762DwoGEIGkyqVY=

--- a/dev/private/flake.lock
+++ b/dev/private/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1731842749,
+        "narHash": "sha256-aNc8irVBH7sM5cGDvqdOueg8S+fGakf0rEMRGfGwWZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bf6132dc791dbdff8b6894c3a85eb27ad8255682",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs-stable": "nixpkgs-stable",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-stable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730321837,
+        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/private/flake.nix
+++ b/dev/private/flake.nix
@@ -1,0 +1,9 @@
+{
+  description = "private inputs";
+  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/release-24.05";
+
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+  inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs-stable";
+
+  outputs = _: { };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,26 +16,9 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -93,11 +93,24 @@
           tests // (suffix-stable tests-stable) // (suffix-stable packages-stable)
         );
 
+        apps = eachSystem (
+          { pkgs, ... }:
+          {
+            update-dev-private-narHash = {
+              type = "app";
+              program = "${pkgs.writeShellScript "update-dev-private-narHash" ''
+                nix --extra-experimental-features "nix-command flakes" flake lock ./dev/private
+                nix --extra-experimental-features "nix-command flakes" hash path ./dev/private | tr -d '\n' > ./dev/private.narHash
+              ''}";
+            };
+          }
+        );
+
         devShells = eachSystem (
           { pkgs, ... }:
           {
             unit-tests = pkgs.callPackage ./pkgs/unit-tests.nix { };
-            default = pkgs.callPackage ./shell.nix { };
+            default = pkgs.callPackage ./shell.nix {};
           }
         );
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Integrates sops into nixos";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/release-24.05";
+
   nixConfig.extra-substituters = [ "https://cache.thalheim.io" ];
   nixConfig.extra-trusted-public-keys = [
     "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
@@ -10,21 +10,41 @@
     {
       self,
       nixpkgs,
-      nixpkgs-stable,
-    }:
+    }@inputs:
     let
+      loadPrivateFlake =
+        path:
+        let
+          flakeHash = builtins.readFile "${toString path}.narHash";
+          flakePath = "path:${toString path}?narHash=${flakeHash}";
+        in
+        builtins.getFlake (builtins.unsafeDiscardStringContext flakePath);
+
+      privateFlake = loadPrivateFlake ./dev/private;
+
+      privateInputs = privateFlake.inputs;
+
       systems = [
         "x86_64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
         "aarch64-linux"
       ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-      suffix-version =
-        version: attrs:
-        nixpkgs.lib.mapAttrs' (name: value: nixpkgs.lib.nameValuePair (name + version) value) attrs;
-      suffix-stable = suffix-version "-24_05";
+
+      eachSystem =
+        f:
+        builtins.listToAttrs (
+          builtins.map (system: {
+            name = system;
+            value = f {
+              pkgs = inputs.nixpkgs.legacyPackages.${system};
+              inherit system;
+            };
+          }) systems
+        );
+
     in
+    # public outputs
     {
       overlays.default =
         final: prev:
@@ -52,39 +72,33 @@
         sops = ./modules/nix-darwin;
         default = self.darwinModules.sops;
       };
-      packages = forAllSystems (
-        system:
-        import ./default.nix {
-          pkgs = import nixpkgs { inherit system; };
-        }
-      );
-      checks =
-        nixpkgs.lib.genAttrs
-          [
-            "x86_64-linux"
-            "aarch64-linux"
-          ]
-          (
-            system:
-            let
-              tests = self.packages.${system}.sops-install-secrets.tests;
-              packages-stable = import ./default.nix {
-                pkgs = import nixpkgs-stable { inherit system; };
-              };
-              tests-stable = packages-stable.sops-install-secrets.tests;
-            in
-            tests // (suffix-stable tests-stable) // (suffix-stable packages-stable)
-          );
+      packages = eachSystem ({ pkgs, ... }: import ./default.nix { inherit pkgs; });
+    }
+    //
+      # dev outputs
+      {
+        checks = eachSystem (
+          { system, ... }:
+          let
+            tests = self.packages.${system}.sops-install-secrets.tests;
+            packages-stable = import ./default.nix {
+              pkgs = privateInputs.nixpkgs-stable.legacyPackages.${system};
+            };
+            tests-stable = packages-stable.sops-install-secrets.tests;
+            suffix-version =
+              version: attrs:
+              nixpkgs.lib.mapAttrs' (name: value: nixpkgs.lib.nameValuePair (name + version) value) attrs;
+            suffix-stable = suffix-version "-24_05";
+          in
+          tests // (suffix-stable tests-stable) // (suffix-stable packages-stable)
+        );
 
-      devShells = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
-          unit-tests = pkgs.callPackage ./pkgs/unit-tests.nix { };
-          default = pkgs.callPackage ./shell.nix { };
-        }
-      );
-    };
+        devShells = eachSystem (
+          { pkgs, ... }:
+          {
+            unit-tests = pkgs.callPackage ./pkgs/unit-tests.nix { };
+            default = pkgs.callPackage ./shell.nix { };
+          }
+        );
+      };
 }

--- a/modules/nix-darwin/secrets-for-users/default.nix
+++ b/modules/nix-darwin/secrets-for-users/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  options,
   config,
   pkgs,
   ...

--- a/pkgs/sops-install-secrets/default.nix
+++ b/pkgs/sops-install-secrets/default.nix
@@ -21,7 +21,9 @@ buildGoModule {
   # requires root privileges for tests
   doCheck = false;
 
-  passthru.tests = callPackages ./nixos-test.nix { };
+  passthru = {
+    tests = lib.optionalAttrs stdenv.isLinux (callPackages ./nixos-test.nix { });
+  };
 
   outputs = [ "out" ] ++ lib.lists.optionals (stdenv.isLinux) [ "unittest" ];
 

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,11 @@ pkgs.mkShell {
     util-linux
     nix
     golangci-lint
+
+    (pkgs.writeScriptBin "update-dev-private-narHash" ''
+      nix --extra-experimental-features "nix-command flakes" flake lock ./dev/private
+      nix --extra-experimental-features "nix-command flakes" hash path ./dev/private | tr -d '\n' > ./dev/private.narHash
+    '')
   ];
   # delve does not compile with hardening enabled
   hardeningDisable = [ "all" ];

--- a/shell.nix
+++ b/shell.nix
@@ -10,11 +10,6 @@ pkgs.mkShell {
     util-linux
     nix
     golangci-lint
-
-    (pkgs.writeScriptBin "update-dev-private-narHash" ''
-      nix --extra-experimental-features "nix-command flakes" flake lock ./dev/private
-      nix --extra-experimental-features "nix-command flakes" hash path ./dev/private | tr -d '\n' > ./dev/private.narHash
-    '')
   ];
   # delve does not compile with hardening enabled
   hardeningDisable = [ "all" ];


### PR DESCRIPTION
Now with home-manager and nix-darwin tests, we don't want to increase
the number of dependencies a user has to override in their flake.lock.