### PR TITLE
modules/nix-darwin/secrets-for-users: empty set instead of empty list

### DIFF
--- a/modules/nix-darwin/secrets-for-users/default.nix
+++ b/modules/nix-darwin/secrets-for-users/default.nix
@@ -37,11 +37,11 @@ in
     }
   ];
 
-  system.activationScripts = lib.mkIf (secretsForUsers != [ ]) {
+  system.activationScripts = lib.mkIf (secretsForUsers != { }) {
     postActivation.text = lib.mkAfter installScript;
   };
 
-  launchd.daemons.sops-install-secrets-for-users = lib.mkIf (secretsForUsers != [ ]) {
+  launchd.daemons.sops-install-secrets-for-users = lib.mkIf (secretsForUsers != { }) {
     command = "sh -c ${lib.escapeShellArg installScript}";
     serviceConfig = {
       RunAtLoad = true;


### PR DESCRIPTION
These were enabled even if there wasn't any user secrets.

Also `SOPS_GPG_EXE` is enabled and gpg, etc is added to the system closure as `sops.gnupg.sshKeyPaths` is set by default, should I just set `sops.gnupg.sshKeyPaths = [ ]` downstream?