### PR TITLE
Fix fast path in atomicSymlink

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -730,7 +730,7 @@ func atomicSymlink(oldname, newname string) error {
 	// Fast path: if newname does not exist yet, we can skip the whole dance
 	// below.
 	if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
-		return fmt.Errorf("cannot create symlink %s: %w", newname, err)
+		return err
 	}
 
 	// We need to use ioutil.TempDir, as we cannot overwrite a ioutil.TempFile,


### PR DESCRIPTION
Fix #708.

1. If `os.Symlink` succeeds (`err == nil`), return `nil` (`err`).
2. If `os.Symlink` fails (`err != nil`), check if the error indicates that a file or directory already exists (`os.IsExist(err)`).
   * If the error is unrelated to a pre-existing file or directory, return `err` as it cannot be handled in `atomicSymlink`.
   * If the error does indicate a pre-existing file or directory, don't return and handle it with the remaining logic in `atomicSymlink`.

```go
// Fast path: if newname does not exist yet, we can skip the whole dance
// below.
if err := os.Symlink(oldname, newname); err == nil || !os.IsExist(err) {
    return err
}
```