### PR TITLE
fix import keys hook using unbound variable

### DIFF
--- a/pkgs/sops-import-keys-hook/sops-import-keys-hook.bash
+++ b/pkgs/sops-import-keys-hook/sops-import-keys-hook.bash
@@ -1,6 +1,6 @@
 sopsImportKeysHook() {
   local key dir
-  if [ -n "${sopsCreateGPGHome}" ]; then
+  if [ -v sopsCreateGPGHome ] && [ -n "${sopsCreateGPGHome}" ]; then
     export GNUPGHOME=${sopsGPGHome:-$(pwd)/.git/gnupg}
     mkdir -m 700 -p $GNUPGHOME
   fi


### PR DESCRIPTION
closes #372

this is an issue for me with `nix-direnv`. i've also tried the suggested solution and it actually does work.