### PR TITLE
fix template rendering with renamed secrets

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -99,7 +99,7 @@ let
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
-        placeholderBySecretName = cfg.placeholder;
+        placeholderBySecretKey = cfg.placeholder;
         userMode = true;
         logging = {
           keyImport = builtins.elem "keyImport" cfg.log;

--- a/modules/nix-darwin/manifest-for.nix
+++ b/modules/nix-darwin/manifest-for.nix
@@ -17,7 +17,7 @@ writeTextFile {
       ageKeyFile = cfg.age.keyFile;
       ageSshKeyPaths = cfg.age.sshKeyPaths;
       useTmpfs = false;
-      placeholderBySecretName = cfg.placeholder;
+      placeholderBySecretKey = cfg.placeholder;
       userMode = false;
       logging = {
         keyImport = builtins.elem "keyImport" cfg.log;

--- a/modules/sops/manifest-for.nix
+++ b/modules/sops/manifest-for.nix
@@ -17,7 +17,7 @@ writeTextFile {
       ageKeyFile = cfg.age.keyFile;
       ageSshKeyPaths = cfg.age.sshKeyPaths;
       useTmpfs = cfg.useTmpfs;
-      placeholderBySecretName = cfg.placeholder;
+      placeholderBySecretKey = cfg.placeholder;
       userMode = false;
       logging = {
         keyImport = builtins.elem "keyImport" cfg.log;

--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -72,7 +72,7 @@ type template struct {
 type manifest struct {
 	Secrets                 []secret          `json:"secrets"`
 	Templates               []template        `json:"templates"`
-	PlaceholderBySecretName map[string]string `json:"placeholderBySecretName"`
+	PlaceholderBySecretKey  map[string]string `json:"placeholderBySecretKey"`
 	SecretsMountPoint       string            `json:"secretsMountPoint"`
 	SymlinkPath             string            `json:"symlinkPath"`
 	KeepGenerations         int               `json:"keepGenerations"`
@@ -704,9 +704,9 @@ func (app *appContext) validateManifest() error {
 		// The Nix module only defines placeholders for secrets if there are
 		// templates.
 		if len(m.Templates) > 0 {
-			placeholder, present := m.PlaceholderBySecretName[secret.Name]
+			placeholder, present := m.PlaceholderBySecretKey[secret.Key]
 			if !present {
-				return fmt.Errorf("placeholder for %s not found in manifest", secret.Name)
+				return fmt.Errorf("placeholder for %s not found in manifest", secret.Key)
 			}
 
 			app.secretByPlaceholder[placeholder] = secret


### PR DESCRIPTION
modules/templates/default.nix generates the placeholders manifest entry by using the name of the secret in the `sops.secrets` attrset. sops-install-secrets looked up the placeholder using the secret name and resolved to the wrong secret when a secret was renamed.

This renames the entry in the manifest from `placeholderBySecretName` to `placeholderBySecretKey` and changes the lookup to use the key instead of the name.

This fixes my issue in #688 but results in a new issue that there can be multiple keys.

I think another solution would be to store the secrets in the manifest in an object instead of a list and use the name of the secret in the `sops.secrets` attrset as the key.