### PR TITLE
ci/update-vendor-hash: use github app token

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -1,18 +1,20 @@
 name: Update vendorHash
 on: pull_request
-
-permissions:
-  contents: write
-
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:


### PR DESCRIPTION
otherwise auto-merge doesn't work