### PR TITLE
home-manager/templates: remove restartUnits/reloadUnits

### DIFF
--- a/modules/home-manager/templates.nix
+++ b/modules/home-manager/templates.nix
@@ -60,24 +60,6 @@ in
                   File used as the template. When this value is specified, `sops.templates.<name>.content` is ignored.
                 '';
               };
-              restartUnits = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
-                default = [ ];
-                example = [ "sshd.service" ];
-                description = ''
-                  Names of units that should be restarted when the rendered template changes.
-                  This works the same way as <xref linkend="opt-systemd.services._name_.restartTriggers" />.
-                '';
-              };
-              reloadUnits = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
-                default = [ ];
-                example = [ "sshd.service" ];
-                description = ''
-                  Names of units that should be reloaded when the rendered template changes.
-                  This works the same way as <xref linkend="opt-systemd.services._name_.reloadTriggers" />.
-                '';
-              };
             };
           }
         )


### PR DESCRIPTION

this feature is not implemented for the home-manager module.

fixes https://github.com/Mic92/sops-nix/issues/729