### PR TITLE
secrets-for-users: set `HOME` envvar to avoid warnings on sops >= 3.10.0

### DIFF
--- a/modules/sops/secrets-for-users/default.nix
+++ b/modules/sops/secrets-for-users/default.nix
@@ -14,7 +14,11 @@ let
     inherit (pkgs) writeTextFile;
   };
   withEnvironment = import ../with-environment.nix {
-    inherit cfg lib;
+    # See also the default NixOS module.
+    cfg = lib.recursiveUpdate cfg {
+      environment.HOME = "/var/empty";
+    };
+    inherit lib;
   };
   manifestForUsers = manifestFor "-for-users" secretsForUsers templatesForUsers {
     secretsMountPoint = "/run/secrets-for-users.d";


### PR DESCRIPTION
Followup for #765, where I missed this, sorry. :upside_down_face: 

It's needed here too, since it runs in the same context as the default NixOS module.