### PR TITLE
docs: install and configure with nix-darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ If you use experimental nix flakes support:
 }
 ```
 
+##### [`nix-darwin`](https://github.com/nix-darwin/nix-darwin)
+
+A module for `nix-darwin` is also available for global install with flakes:
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nix-darwin.url = "github:nix-darwin/nix-darwin/master";
+  inputs.nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.sops-nix.url = "github:Mic92/sops-nix";
+  #inputs.sops-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = { self, nix-darwin, nixpkgs, sops-nix }: {
+    darwinConfigurations.yourhostname = nix-darwin.lib.darwinSystem {
+      modules = [
+        ./configuration.nix
+        sops-nix.darwinModules.sops
+      ];
+    };
+  };
+}
+```
+
 #### [`niv`](https://github.com/nmattia/niv) (recommended if not using flakes)
   First add it to niv:
   
@@ -154,6 +177,8 @@ $ ssh-keygen -p -N "" -f /tmp/id_rsa
 $ nix-shell -p gnupg -p ssh-to-pgp --run "ssh-to-pgp -private-key -i /tmp/id_rsa | gpg --import --quiet"
 $ rm /tmp/id_rsa
 ```
+
+When using `nix-darwin` save the `age` key to `$HOME/Library/Application Support/sops/age/keys.txt` or set a [custom](https://github.com/getsops/sops#23encrypting-using-age) configuration directory.
 
 <details>
 <summary> How to find the public key of an `age` key </summary>


### PR DESCRIPTION
👋 This PR adds notes on installing and configuring `sops-nix` with [`nix-darwin`](https://github.com/nix-darwin/nix-darwin) for #409!

I found these were the only changes needed when setting things up, with the later steps for setting up `sops` all matching well.