### PR TITLE
Add native support for ssh keys for age

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -337,19 +337,6 @@ in
       }
     ];
 
-    warnings = [
-      (lib.mkIf
-        (
-          cfg.age.sshKeyPaths != [ ]
-          && cfg.gnupg.sshKeyPaths == [ ]
-          && cfg.gnupg.home == null
-          && cfg.age.keyFile == null
-          && cfg.age.sshKeyFile == null
-        )
-        "The option sops.age.sshKeyPaths has been deprecated, since age now has native SSH support. Use option sops.age.sshKeyFile instead."
-      )
-    ];
-
     home.sessionVariables = lib.mkIf cfg.gnupg.qubes-split-gpg.enable {
       # TODO: Add this package to nixpkgs and use it from the store
       # https://github.com/QubesOS/qubes-app-linux-split-gpg

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -257,6 +257,8 @@ in
         example = "/home/someuser/.ssh/id_ed25519";
         description = ''
           Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of the native ssh key support in age and requires no conversion.
         '';
       };
 
@@ -264,10 +266,10 @@ in
         type = lib.types.listOf lib.types.path;
         default = [ ];
         description = ''
-          Paths to ssh keys added as age keys during sops description. The ssh
-          keys will be converted into age keys manually using ssh-to-age.
-
-          This option is deprecated and will be removed in the future. Use sops.age.sshKeyFile instead.
+          Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
     };

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -258,7 +258,8 @@ in
         description = ''
           Path to ssh key file that will be used by age for sops decryption.
           
-          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of the native ssh key support in age and requires no conversion.
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
         '';
       };
 

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -396,19 +396,6 @@ in
     })
 
     {
-      warnings = [
-        (lib.mkIf
-          (
-            cfg.age.sshKeyPaths != [ ]
-            && cfg.gnupg.sshKeyPaths == [ ]
-            && cfg.gnupg.home == null
-            && cfg.age.keyFile == null
-            && cfg.age.sshKeyFile == null
-          )
-          "The option sops.age.sshKeyPaths has been deprecated, since age now has native SSH support. Use option sops.age.sshKeyFile instead."
-        )
-      ];
-
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
         lib.mkDefault "${pkgs.gnupg}/bin/gpg"
       );

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -306,6 +306,9 @@ in
         example = "/etc/ssh/ssh_host_ed25519_key";
         description = ''
           Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
         '';
       };
 
@@ -314,10 +317,10 @@ in
         default = defaultImportKeys "ed25519";
         defaultText = lib.literalMD "The ed25519 keys from {option}`config.services.openssh.hostKeys`";
         description = ''
-          Paths to ssh keys added as age keys during sops description. The ssh
-          keys will be converted into age keys manually using ssh-to-age.
-
-          This option is deprecated and will be removed in the future. Use sops.age.sshKeyFile instead.
+          Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
     };

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -300,12 +300,24 @@ in
         '';
       };
 
+      sshKeyFile = lib.mkOption {
+        type = lib.types.nullOr pathNotInStore;
+        default = null;
+        example = "/etc/ssh/ssh_host_ed25519_key";
+        description = ''
+          Path to ssh key file that will be used by age for sops decryption.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
         defaultText = lib.literalMD "The ed25519 keys from {option}`config.services.openssh.hostKeys`";
         description = ''
-          Paths to ssh keys added as age keys during sops description.
+          Paths to ssh keys added as age keys during sops description. The ssh
+          keys will be converted into age keys manually using ssh-to-age.
+
+          This option is deprecated and will be removed in the future. Use sops.age.sshKeyFile instead.
         '';
       };
     };
@@ -345,6 +357,7 @@ in
               cfg.gnupg.home != null
               || cfg.gnupg.sshKeyPaths != [ ]
               || cfg.age.keyFile != null
+              || cfg.age.sshKeyFile != null
               || cfg.age.sshKeyPaths != [ ];
             message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home";
           }
@@ -383,6 +396,19 @@ in
     })
 
     {
+      warnings = [
+        (lib.mkIf
+          (
+            cfg.age.sshKeyPaths != [ ]
+            && cfg.gnupg.sshKeyPaths == [ ]
+            && cfg.gnupg.home == null
+            && cfg.age.keyFile == null
+            && cfg.age.sshKeyFile == null
+          )
+          "The option sops.age.sshKeyPaths has been deprecated, since age now has native SSH support. Use option sops.age.sshKeyFile instead."
+        )
+      ];
+
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
         lib.mkDefault "${pkgs.gnupg}/bin/gpg"
       );

--- a/modules/nix-darwin/manifest-for.nix
+++ b/modules/nix-darwin/manifest-for.nix
@@ -15,6 +15,7 @@ writeTextFile {
       gnupgHome = cfg.gnupg.home;
       sshKeyPaths = cfg.gnupg.sshKeyPaths;
       ageKeyFile = cfg.age.keyFile;
+      ageSshKeyFile = cfg.age.sshKeyFile;
       ageSshKeyPaths = cfg.age.sshKeyPaths;
       useTmpfs = false;
       placeholderBySecretName = cfg.placeholder;

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -345,6 +345,8 @@ in
         example = "/etc/ssh/ssh_host_ed25519_key";
         description = ''
           Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of the native ssh key support in age and requires no conversion.
         '';
       };
 
@@ -353,10 +355,10 @@ in
         default = defaultImportKeys "ed25519";
         defaultText = lib.literalMD "The ed25519 keys from {option}`config.services.openssh.hostKeys`";
         description = ''
-          Paths to ssh keys added as age keys during sops description. The ssh
-          keys will be converted into age keys manually using ssh-to-age.
-
-          This option is deprecated and will be removed in the future. Use sops.age.sshKeyFile instead.
+          Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
     };

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -346,7 +346,8 @@ in
         description = ''
           Path to ssh key file that will be used by age for sops decryption.
           
-          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of the native ssh key support in age and requires no conversion.
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
         '';
       };
 

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -496,19 +496,6 @@ in
       };
     })
     {
-      warnings = [
-        (lib.mkIf
-          (
-            cfg.age.sshKeyPaths != [ ]
-            && cfg.gnupg.sshKeyPaths == [ ]
-            && cfg.gnupg.home == null
-            && cfg.age.keyFile == null
-            && cfg.age.sshKeyFile == null
-          )
-          "The option sops.age.sshKeyPaths has been deprecated, since age now has native SSH support. Use option sops.age.sshKeyFile instead."
-        )
-      ];
-
       system.build.sops-nix-manifest = manifest;
     }
   ];

--- a/modules/sops/manifest-for.nix
+++ b/modules/sops/manifest-for.nix
@@ -40,6 +40,7 @@ else
         gnupgHome = cfg.gnupg.home;
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
+        ageSshKeyFile = cfg.age.sshKeyFile;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
         useTmpfs = cfg.useTmpfs;
         placeholderBySecretName = cfg.placeholder;

--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -79,6 +79,7 @@ type manifest struct {
 	SSHKeyPaths             []string          `json:"sshKeyPaths"`
 	GnupgHome               string            `json:"gnupgHome"`
 	AgeKeyFile              string            `json:"ageKeyFile"`
+	AgeSSHKeyFile           string            `json:"ageSshKeyFile"`
 	AgeSSHKeyPaths          []string          `json:"ageSshKeyPaths"`
 	UseTmpfs                bool              `json:"useTmpfs"`
 	UserMode                bool              `json:"userMode"`
@@ -1325,7 +1326,7 @@ func installSecrets(args []string) error {
 	}
 
 	// Import age keys
-	if len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "" {
+	if (len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "") && manifest.AgeSSHKeyFile == "" {
 		keyfile := filepath.Join(manifest.SecretsMountPoint, "age-keys.txt")
 		os.Setenv("SOPS_AGE_KEY_FILE", keyfile)
 		// Create the keyfile
@@ -1358,6 +1359,10 @@ func installSecrets(args []string) error {
 				return fmt.Errorf("cannot write key to age file: %w", err)
 			}
 		}
+	}
+
+	if manifest.AgeSSHKeyFile != "" {
+		os.Setenv("SOPS_AGE_SSH_PRIVATE_KEY_FILE", manifest.AgeSSHKeyFile)
 	}
 
 	if err := decryptSecrets(manifest.Secrets); err != nil {


### PR DESCRIPTION
Adds support for the age's native SSH feature from https://github.com/getsops/sops/pull/1692.

Also deprecates `sops.age.sshKeyPaths` as it should no longer be necessary.

Closes https://github.com/Mic92/sops-nix/issues/744