### PR TITLE
use homeModules for the home-manager module output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
         default = self.homeManagerModules.sops;
       };
       homeManagerModule = self.homeManagerModules.sops;
+      homeModules = self.homeManagerModules;
       darwinModules = {
         sops = ./modules/nix-darwin;
         default = self.darwinModules.sops;


### PR DESCRIPTION
`homeModules` is the proper name for the output attribute of home-manager modules.

https://github.com/nix-community/home-manager/blob/45c2985644b60ab64de2a2d93a4d132ecb87cf66/flake-module.nix#L23C1-L25C87:

> `homeConfigurations` is for specific installations. If you want to expose
> reusable configurations, add them to `homeModules` in the form of modules, so
> that you can reference them in this or another flake's `homeConfigurations`.

`homeManagerModules` and `homeManagerModule` are kept for backwards compatibility.