### PR TITLE
Fix checks and tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@ in
 rec {
   inherit sops-install-secrets;
   sops-init-gpg-key = pkgs.callPackage ./pkgs/sops-init-gpg-key { };
+  sops-pgp-hook = pkgs.callPackage ./pkgs/sops-pgp-hook { };
   default = sops-init-gpg-key;
 
   sops-import-keys-hook = pkgs.callPackage ./pkgs/sops-import-keys-hook { };

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,10 @@
             packages-stable = import ./default.nix {
               pkgs = privateInputs.nixpkgs-stable.legacyPackages.${system};
             };
-            dropOverride = attrs: nixpkgs.lib.removeAttrs attrs [ "override" ];
+            dropOverride = attrs: nixpkgs.lib.removeAttrs attrs [
+              "override"
+              "overrideDerivation"
+            ];
             tests = dropOverride (pkgs.callPackage ./checks/nixos-test.nix { });
             tests-stable = dropOverride (
               privateInputs.nixpkgs-stable.legacyPackages.${system}.callPackage ./checks/nixos-test.nix { }


### PR DESCRIPTION
change to default.nix resolves `nix develop .#unit-tests` error:
```
➜  nix develop .#unit-tests
warning: ignoring untrusted substituter 'https://cache.thalheim.io', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: ignoring untrusted substituter 'https://cache.thalheim.io', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
++ NIX_PATH=nixpkgs=/nix/store/ninkaf94v6231yv0pyx401zfsw8pkxxx-source
+++ realpath ./pkgs/sops-pgp-hook/test-assets
++ TEST_ASSETS=/home/sean/src/sops-nix/pkgs/sops-pgp-hook/test-assets
++ sops-pgp-hook.test
$ nix-shell shell.nix --run echo SOPS_PGP_FP=$SOPS_PGP_FP
stdout:

stderr:
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/ninkaf94v6231yv0pyx401zfsw8pkxxx-source/pkgs/stdenv/generic/make-derivation.nix:438:13

       … while evaluating attribute 'nativeBuildInputs' of derivation 'nix-shell'
         at /nix/store/ninkaf94v6231yv0pyx401zfsw8pkxxx-source/pkgs/stdenv/generic/make-derivation.nix:490:13:
          489|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          490|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          491|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'sops-pgp-hook' missing
       at /home/sean/src/sops-nix/pkgs/sops-pgp-hook/test-assets/shell.nix:12:5:
           11|   nativeBuildInputs = [
           12|     (pkgs.callPackage ../../.. { }).sops-pgp-hook
             |     ^
           13|   ];

hook_test.go:44: unexpected error: exit status 1

--- FAIL: TestShellHook (0.28s)
FAIL
+++ realpath ./pkgs/sops-install-secrets/test-assets
++ sudo TEST_ASSETS=/home/sean/src/sops-nix/pkgs/sops-install-secrets/test-assets unshare --mount --fork sops-install-secrets.test
gpg: keybox '/tmp/symlinkDir1780503372/gpg-home/pubring.kbx' created
gpg: /tmp/symlinkDir1780503372/gpg-home/trustdb.gpg: trustdb created
gpg: key F9BA9DEBD03F57C0: public key "krops-test <root@krops-test>" imported
gpg: key F9BA9DEBD03F57C0: secret key imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg:       secret keys read: 1
gpg:   secret keys imported: 1
PASS
+ command rm -f /tmp/nix-shell.G9HWJa
+ shopt -s expand_aliases
```

change to flake.nix resolve `nix flake check` error:
```
➜  nix flake check
warning: ignoring untrusted substituter 'https://cache.thalheim.io', you are not a trusted user.
Run `man nix.conf` for more information on the `substituters` configuration option.
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: unknown flake output 'homeManagerModules'
warning: unknown flake output 'homeManagerModule'
error:
       … while checking flake output 'checks'
         at /nix/store/hm2xjph72wvprhcy3008qyj5bkcjzbpw-source/flake.nix:83:9:
           82|       {
           83|         checks = eachSystem (
             |         ^
           84|           { pkgs, system, ... }:

       … while checking the derivation 'checks.x86_64-linux.overrideDerivation'
         at /nix/store/ninkaf94v6231yv0pyx401zfsw8pkxxx-source/lib/customisation.nix:177:11:
          176|           override = overrideArgs;
          177|           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
             |           ^
          178|           ${if result ? overrideAttrs then "overrideAttrs" else null} =

       error: flake attribute 'checks.x86_64-linux.overrideDerivation' is not a derivation

```