### PR TITLE
also replace runtimedir for template paths in user mode

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -1286,6 +1286,12 @@ func installSecrets(args []string) error {
 			newSecrets = append(newSecrets, secret)
 		}
 		manifest.Secrets = newSecrets
+		var newTemplates []template
+		for _, template := range manifest.Templates {
+			template.Path = replaceRuntimeDir(template.Path, rundir)
+			newTemplates = append(newTemplates, template)
+		}
+		manifest.Templates = newTemplates
 	}
 
 	app := appContext{


### PR DESCRIPTION
For secrets, there is a feature that replaces any `%r` in the configured path of the secret with the users runtime_dir.

This feature is currently missing for templates.

My use case for applying it to templates is generating the `${XDG_RUNTIME_DIR}/containers/auth.json` file used by podman (or oci in general).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template paths now correctly resolve to the runtime directory when running in user mode, matching how secrets mounts and symlinks are handled.
  * Prevents missing-template errors and misplacements during secret installation in user-mode setups.
  * Improves reliability and consistency across environments; no changes for system mode or other workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->