### PR TITLE
sops-install-secrets: use noswap mount option with tmpfs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 {
   pkgs ? import <nixpkgs> { },
-  vendorHash ? "sha256-M1+oE8rbv8GN0n+EifRBG7IanHCE4JbnD0JrJD/N7Sk=",
+  vendorHash ? "sha256-Ni9gJP1tjPlrLRVILgubJVNAzEtmhI6rN8xNaGYy9TU=",
 }:
 let
   sops-install-secrets = pkgs.callPackage ./pkgs/sops-install-secrets {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/getsops/sops/v3 v3.10.2
 	github.com/joho/godotenv v1.5.1
+	github.com/moby/sys/mountinfo v0.7.2
 	github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625
 	golang.org/x/crypto v0.41.0
 	golang.org/x/sys v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/user v0.3.0 h1:9ni5DlcW5an3SvRSx4MouotOygvzaXbaSrc/wGDFWPo=
 github.com/moby/sys/user v0.3.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -306,7 +306,7 @@ in
         Use tmpfs in place of ramfs for secrets storage.
 
         *WARNING*
-        Enabling this option has the potential to write secrets to disk unencrypted if the tmpfs volume is written to swap. Do not use unless absolutely necessary.
+        On Linux kernels earlier than 6.4, enabling this option has the potential to write secrets to disk unencrypted if the tmpfs volume is written to swap. Do not use unless absolutely necessary.
 
         When using a swap file or device, consider enabling swap encryption by setting the `randomEncryption.enable` option
 


### PR DESCRIPTION
I think we can assume the `noswap` tmpfs mount option is available, as Linux 6.4 was released 2 years ago. 

I had to use another package to check if the secrets directory is a mountpoint, since only checking if the filesystem type is tmpfs doesn't work when the parent directory `/run` is usually tmpfs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More reliable secret-mount behavior with a safer, more resilient mounting flow.
- Bug Fixes
  - Improved mount detection, fallback handling, and clearer error reporting for increased stability.
- Documentation
  - Conditioned tmpfs warning for older Linux kernels to reduce unnecessary alerts.
- Dependencies
  - Added/updated mount-related library to improve mount detection.
- Chores
  - Updated default build metadata (vendor hash).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->