### PR TITLE
fix changing between a secret file and a directory with the same name

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -966,8 +966,8 @@ func handleModifications(isDry bool, logcfg loggingConfig, symlinkPath string, s
 		// Read the old file
 		oldData, err := os.ReadFile(oldPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				// File did not exist before
+			// File did not exist before or the path changed from a file to a directory or vice versa
+			if os.IsNotExist(err) || errors.Is(err, syscall.ENOTDIR) || errors.Is(err, syscall.EISDIR) {
 				restart = append(restart, secret.RestartUnits...)
 				reload = append(reload, secret.ReloadUnits...)
 				newSecrets[secret.Name] = true
@@ -997,8 +997,8 @@ func handleModifications(isDry bool, logcfg loggingConfig, symlinkPath string, s
 		// Read the old file
 		oldData, err := os.ReadFile(oldPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				// File did not exist before
+			// File did not exist before or the path changed from a file to a directory or vice versa
+			if os.IsNotExist(err) || errors.Is(err, syscall.ENOTDIR) || errors.Is(err, syscall.EISDIR) {
 				restart = append(restart, template.RestartUnits...)
 				reload = append(reload, template.ReloadUnits...)
 				newTemplates[template.Name] = true


### PR DESCRIPTION
This fixes #523, which https://github.com/Mic92/sops-nix/pull/707 actually doesn't address.

This also fixes changing `{ sops.secrets."foo/bar" = {}; }` back to `{ sops.secrets.foo = {}; }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Transitions where a secret or rendered template changes between a file and a directory are now detected and treated as new items: the system will enqueue automatic reloads/restarts and skip further processing for the affected item to prevent errors and stale state.

- New Features
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->