### PR TITLE
Update stable to 25.05

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,55 @@
+version: "2"
 linters:
-  presets:
-    - bugs
-    - unused
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testifylint
+    - unparam
+    - zerologlint
+  disable:
+    - noctx
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gofmt
-    - misspell
-    - revive
-    - stylecheck
-  disable:
-    # direnv is not a web server, context is not strictly necessary.
-    - noctx
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - exhaustive
     - gocheckcompilerdirectives
     - gochecksumtype
-    - gosec
     - gosmopolitan
     - loggercheck
     - makezero

--- a/dev/private.narHash
+++ b/dev/private.narHash
@@ -1,1 +1,1 @@
-sha256-N0rLdSen6qnka4+Q9hCp/13trx2KFC9MHf+PvgIwJ4I=
+sha256-PTJ4p+trFbJrX6ox+7XypGENx7aTPQTl3aJkm62t5ZA=

--- a/dev/private/flake.lock
+++ b/dev/private/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745071558,
-        "narHash": "sha256-bvcatss0xodcdxXm0LUSLPd2jjrhqO3yFSu3stOfQXg=",
+        "lastModified": 1757385184,
+        "narHash": "sha256-LCxtQn9ajvOgGRbQIRUJgfP7clMGGvV1SDW1HcSb0zk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9676e8a52a177d80c8a42f66566362a6d74ecf78",
+        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744478979,
-        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "lastModified": 1757430124,
+        "narHash": "sha256-MhDltfXesGH8VkGv3hmJ1QEKl1ChTIj9wmGAFfWj/Wk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "rev": "830b3f0b50045cf0bcfd4dab65fad05bf882e196",
         "type": "github"
       },
       "original": {
@@ -42,16 +42,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
-        "ref": "nixos-24.11",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "lastModified": 1757408970,
+        "narHash": "sha256-aSgK4BLNFFGvDTNKPeB28lVXYqVn8RdyXDNAvgGq+k0=",
+        "ref": "nixos-25.05",
+        "rev": "d179d77c139e0a3f5c416477f7747e9d6b7ec315",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
       },
       "original": {
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -59,10 +59,10 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "ref": "nixpkgs-unstable",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {

--- a/dev/private/flake.nix
+++ b/dev/private/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "private inputs";
 
-  inputs.nixpkgs-stable.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixos-24.11";
+  inputs.nixpkgs-stable.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixos-25.05";
 
   inputs.nixpkgs-unstable.url = "git+https://github.com/NixOS/nixpkgs?shallow=1&ref=nixpkgs-unstable";
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
             suffix-version =
               version: attrs:
               nixpkgs.lib.mapAttrs' (name: value: nixpkgs.lib.nameValuePair (name + version) value) attrs;
-            suffix-stable = suffix-version "-24_05";
+            suffix-stable = suffix-version "-25_05";
           in
           {
             home-manager = self.legacyPackages.${system}.homeConfigurations.sops.activation-script;

--- a/pkgs/sops-install-secrets/default.nix
+++ b/pkgs/sops-install-secrets/default.nix
@@ -20,17 +20,17 @@ buildGo124Module {
   # requires root privileges for tests
   doCheck = false;
 
-  outputs = [ "out" ] ++ lib.lists.optionals (stdenv.isLinux) [ "unittest" ];
+  outputs = [ "out" ] ++ lib.optional stdenv.isLinux "unittest";
 
   postInstall =
     ''
       go test -c ./pkgs/sops-install-secrets
     ''
-    + lib.optionalString (stdenv.isLinux) ''
+    + lib.optionalString stdenv.isLinux ''
       # *.test is only tested on linux. $unittest does not exist on darwin.
       install -D ./sops-install-secrets.test $unittest/bin/sops-install-secrets.test
       # newer versions of nixpkgs no longer require this step
-      if command -v remove-references-to; then
+      if command -v remove-references-to >/dev/null; then
         remove-references-to -t ${go} $unittest/bin/sops-install-secrets.test
       fi
     '';

--- a/pkgs/sops-install-secrets/default.nix
+++ b/pkgs/sops-install-secrets/default.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   stdenv,
   vendorHash,
   go,
 }:
-buildGoModule {
+buildGo124Module {
   pname = "sops-install-secrets";
   version = "0.0.1";
 

--- a/pkgs/sops-install-secrets/main_test.go
+++ b/pkgs/sops-install-secrets/main_test.go
@@ -42,7 +42,7 @@ func writeManifest(t *testing.T, dir string, m *manifest) string {
 	ok(t, err)
 	encoder := json.NewEncoder(f)
 	ok(t, encoder.Encode(m))
-	f.Close()
+	_ = f.Close()
 	return filename
 }
 
@@ -60,7 +60,7 @@ type testDir struct {
 }
 
 func (dir testDir) Remove() {
-	os.RemoveAll(dir.path)
+	_ = os.RemoveAll(dir.path)
 }
 
 func newTestDir(t *testing.T) testDir {
@@ -215,7 +215,7 @@ func testSSHKey(t *testing.T) {
 	target := path.Join(testdir.path, "existing-target")
 	file, err := os.Create(target)
 	ok(t, err)
-	file.Close()
+	_ = file.Close()
 
 	nobody := "nobody"
 	nogroup := "nogroup"
@@ -250,7 +250,7 @@ func TestAge(t *testing.T) {
 	target := path.Join(testdir.path, "existing-target")
 	file, err := os.Create(target)
 	ok(t, err)
-	file.Close()
+	_ = file.Close()
 
 	nobody := "nobody"
 	nogroup := "nogroup"
@@ -285,7 +285,7 @@ func TestAgeWithSSH(t *testing.T) {
 	target := path.Join(testdir.path, "existing-target")
 	file, err := os.Create(target)
 	ok(t, err)
-	file.Close()
+	_ = file.Close()
 
 	nobody := "nobody"
 	nogroup := "nogroup"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Upgraded stable Nixpkgs/NixOS base to 25.05 and updated developer build identifiers and artifact hash.
  * Broadened and reorganized Go linter and formatter configuration to expand lint coverage and manage generated/false-positive exclusions.
* Build
  * sops-install-secrets now built with the Go 1.24 toolchain and installs a Linux-only test binary.
* Bug Fix / UX
  * Improved error handling in macOS mount flow; secret install no longer fails on age SSH import errors.
* Tests
  * Minor test adjustments to silence linter warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->