### PR TITLE
Revert "modules/sops: allow forcing systemd-based activation"

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -29,6 +29,10 @@ let
   # Currently, all templates are "regular" (there's no support for `neededForUsers` for templates.)
   regularTemplates = cfg.templates;
 
+  useSystemdActivation =
+    (options.systemd ? sysusers && config.systemd.sysusers.enable)
+    || (options.services ? userborn && config.services.userborn.enable);
+
   withEnvironment = import ./with-environment.nix {
     # sops >=3.10.0 now unconditionally searches 
     # for an SSH key in $HOME/.ssh/, introduced in #1692 [0]. Since in the
@@ -315,19 +319,6 @@ in
       '';
     };
 
-    useSystemdActivation = lib.mkOption {
-      type = lib.types.bool;
-      default =
-        (options.systemd ? sysusers && config.systemd.sysusers.enable)
-        || (options.services ? userborn && config.services.userborn.enable);
-      description = ''
-        Use a systemd unit to install secrets, instead of deploying them using an activation script.
-
-        This option is automatically enabled when systemd-sysusers or userborn are used to manage users and groups.
-        It can also be useful to specify additional dependencies to be satisfied before secrets are installed, such as required mountpoints for SOPS key files.
-      '';
-    };
-
     age = {
       keyFile = lib.mkOption {
         type = lib.types.nullOr pathNotInStore;
@@ -442,7 +433,7 @@ in
       );
 
       # When using sysusers we no longer are started as an activation script because those are started in initrd while sysusers is started later.
-      systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && cfg.useSystemdActivation) {
+      systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && useSystemdActivation) {
         wantedBy = [ "sysinit.target" ];
         after = [ "systemd-sysusers.service" ];
         environment = cfg.environment;
@@ -456,7 +447,7 @@ in
       };
 
       system.activationScripts = {
-        setupSecrets = lib.mkIf (regularSecrets != { } && !cfg.useSystemdActivation) (
+        setupSecrets = lib.mkIf (regularSecrets != { } && !useSystemdActivation) (
           lib.stringAfter
             (
               [


### PR DESCRIPTION

This reverts commit b80c966e70fa0615352c9596315678df1de75801.

See https://github.com/Mic92/sops-nix/issues/856
