### PR TITLE
sops-ssh-to-age: remove broken ref in overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,6 @@
             sops-init-gpg-key
             sops-pgp-hook
             sops-import-keys-hook
-            sops-ssh-to-age
             ;
           # backward compatibility
           inherit (prev) ssh-to-pgp;


### PR DESCRIPTION
The overlay provided by the flake in this repository references `sops-ssh-to-age`, but that hasn't existed since it was renamed in 6c916c1 (Add a converter from private ssh keys to age, 2021-08-28) then removed in f636296 (Switch the libs to now external ones, 2021-09-01).