### PR TITLE
modules/sops: re-run sops-install-secrets.service at sysinit-reactivation.target

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -448,7 +448,9 @@ in
       # When using sysusers we no longer are started as an activation script because those are started in initrd while sysusers is started later.
       systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && cfg.useSystemdActivation) {
         wantedBy = [ "sysinit.target" ];
-        after = [ "systemd-sysusers.service" ];
+        after = [ "systemd-sysusers.service" "userborn.service" ];
+        requiredBy = [ "sysinit-reactivation.target" ];
+        before = [ "sysinit-reactivation.target" ];
         environment = cfg.environment;
         unitConfig.DefaultDependencies = "no";
 


### PR DESCRIPTION
Consider the following case: a service (`gitlab-runner.service` in this case) gets a new secret that is installed via sops and will be reloaded on a switch. Right now this would fail like this:

    machine | updating GRUB 2 menu...
    machine | stopping the following units: sops-install-secrets.service
    machine | activating the configuration...
    machine | setting up /etc...
    [...]
    machine | restarting sysinit-reactivation.target
    machine | reloading the following units: dbus-broker.service, gitlab-runner.service
    machine | restarting the following units: polkit.service
    machine | starting the following units: sops-install-secrets.service

Here, the reload happens _before_ running `sops-install-secrets.service` which means that the newly added secret doesn't exist yet and thus the reload fails.

This change makes sure the service is started when running `sysinit-reactivation.target`, i.e. before stc-ng reloads other services. This is what sysusers already does, so the objective of running after sysusers is still met.

Also, added an `After=userborn.service` to make sure it's also ordered after userborn if necessary.

Thank you @WilliButz for reminding me that `sysinit-reactivation.target` exists and is most likely the culprit of that!

cc @mic92

