### PR TITLE
Added `package` option for `gnupg`.

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -269,6 +269,16 @@ in
     };
 
     gnupg = {
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.gnupg;
+        defaultText = lib.literalExpression "pkgs.gnupg";
+        description = ''
+          The gnupg package to use for sops operations. 
+          Useful if you need a specific version or a wrapped instance.
+        '';
+      };
+
       home = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
@@ -341,7 +351,7 @@ in
     sops.environment = {
       SOPS_GPG_EXEC = lib.mkMerge [
         (lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
-          lib.mkDefault "${pkgs.gnupg}/bin/gpg"
+          lib.mkDefault "${cfg.gnupg.package}/bin/gpg"
         ))
         (lib.mkIf cfg.gnupg.qubes-split-gpg.enable (
           lib.mkDefault config.home.sessionVariables.SOPS_GPG_EXEC

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -384,7 +384,7 @@ in
 
     {
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
-        lib.mkDefault "${pkgs.gnupg}/bin/gpg"
+        lib.mkDefault "${cfg.gnupg.package}/bin/gpg"
       );
     }
   ];

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -381,6 +381,16 @@ in
           This option must be explicitly unset if <literal>config.sops.gnupg.home</literal> is set.
         '';
       };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.gnupg;
+        defaultText = lib.literalExpression "pkgs.gnupg";
+        description = ''
+          The gnupg package to use for sops operations.
+        '';
+      };
+      
     };
   };
   imports = [
@@ -442,7 +452,7 @@ in
         );
 
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
-        lib.mkDefault "${pkgs.gnupg}/bin/gpg"
+        lib.mkDefault "${cfg.gnupg.package}/bin/gpg"
       );
 
       # When using sysusers we no longer are started as an activation script because those are started in initrd while sysusers is started later.


### PR DESCRIPTION
Added a `package` option for `gnupg`. This is useful, for instance, to allow usage with bleeding-edge GPG, which supports post-quantum encryption algos such as Kyber, defusing the "store now, decrypt later" threat model.