### PR TITLE
Remove plain annoying toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/Mic92/sops-nix
 
 go 1.24.0
 
-toolchain go1.24.1
-
 require (
 	github.com/Mic92/ssh-to-age v0.0.0-20240115094500-460a2109aaf0
 	github.com/ProtonMail/go-crypto v1.3.0


### PR DESCRIPTION
People are expected to use nix-shell/nix develop or to have at least go 1.24 installed and we don't want to download any go runtimes on build.