### PR TITLE
fix(home-manager): ensure system paths in LaunchAgent PATH on Darwin

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -365,7 +365,12 @@ in
         ))
       ];
 
-      PATH = lib.makeBinPath cfg.age.plugins;
+      PATH =
+        let
+          pluginPaths = lib.makeBinPath cfg.age.plugins;
+          systemPaths = lib.optionalString pkgs.stdenv.isDarwin "/usr/bin:/bin:/usr/sbin:/sbin";
+        in
+        lib.concatStringsSep ":" (lib.filter (p: p != "") [ pluginPaths systemPaths ]);
 
       QUBES_GPG_DOMAIN = lib.mkIf cfg.gnupg.qubes-split-gpg.enable (
         lib.mkDefault cfg.gnupg.qubes-split-gpg.domain


### PR DESCRIPTION
The LaunchAgent on macOS failed when no age plugins were configured because PATH was empty, causing sops-install-secrets to fail finding 'getconf' at /usr/bin/getconf.

Fixes #890