### PR TITLE
Wait for local-fs.target in sops-install-secrets.service

### DIFF
--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -467,7 +467,7 @@ in
       # When using sysusers we no longer are started as an activation script because those are started in initrd while sysusers is started later.
       systemd.services.sops-install-secrets = lib.mkIf (regularSecrets != { } && cfg.useSystemdActivation) {
         wantedBy = [ "sysinit.target" ];
-        after = [ "systemd-sysusers.service" "userborn.service" ];
+        after = [ "local-fs.target" "systemd-sysusers.service" "userborn.service" ];
         requiredBy = [ "sysinit-reactivation.target" ];
         before = [ "sysinit-reactivation.target" ];
         environment = cfg.environment;


### PR DESCRIPTION
This PR updates `sops-install-secrets.service` to wait for [`local-fs.target`](https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#local-fs.target) (also see this [handy diagram](https://www.freedesktop.org/software/systemd/man/latest/bootup.html#System%20Manager%20Bootup)). This target depends on entries in `/etc/fstab`, among other things. The [impermanence](https://github.com/nix-community/impermanence) module also adds its mounts as dependencies.

This fixes two edge cases:

- Where the secrets file is stored on a filesystem not `neededForBoot`, it often cannot be read
- When a secret `path` is set to a filesystem other than `/`, it is often linked to the parent filesystem's mount directory before the child filesystem is mounted

I am not sure, however, if this breaks other usecases where sops-nix is used _for_ mounting filesystems in any way.

May solve https://github.com/Mic92/sops-nix/issues/149.