### PR TITLE
Add args option for age key generation

### DIFF
--- a/checks/darwin.nix
+++ b/checks/darwin.nix
@@ -27,5 +27,6 @@
   };
   sops.defaultSopsFile = ../pkgs/sops-install-secrets/test-assets/secrets.yaml;
   sops.age.generateKey = true;
+  sops.age.extraGenerateKeyArgs = [ "-pq" ];
   system.stateVersion = 5;
 }

--- a/checks/home-manager.nix
+++ b/checks/home-manager.nix
@@ -9,6 +9,7 @@
   home.enableNixpkgsReleaseCheck = false;
 
   sops.age.generateKey = true;
+  sops.age.extraGenerateKeyArgs = [ "-pq" ];
   sops.age.keyFile = "${config.home.homeDirectory}/.age-key.txt";
   sops.secrets.test_key = { };
   sops.templates."template.toml".content = ''

--- a/checks/nixos-test.nix
+++ b/checks/nixos-test.nix
@@ -198,6 +198,30 @@ in
     '';
   };
 
+  # This test should be altered or removed if `age-keygen` switches its default to match the post-quantum `-pq` behavior.
+  age-extra-generate-key-args = testers.runNixOSTest {
+    name = "age-generate-key-args";
+    nodes.machine =
+      { ... }:
+      {
+        imports = [ ../modules/sops ];
+        sops = {
+          age = {
+            keyFile = "/run/age-keys-args.txt";
+            generateKey = true;
+            extraGenerateKeyArgs = [ "-pq" ];
+          };
+          defaultSopsFile = testAssets + "/secrets.yaml";
+          secrets.test_key = { };
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.succeed("cat /run/age-keys-args.txt | grep -q AGE-SECRET-KEY-PQ-")
+    '';
+  };
+
   age-ssh-keys = testers.runNixOSTest {
     name = "sops-age-ssh-keys";
     nodes.machine = {

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -121,7 +121,7 @@ let
     pkgs.writeShellScript "sops-nix-user" (
       lib.optionalString cfg.age.generateKey ''
         if [[ ! -f ${escapedAgeKeyFile} ]]; then
-          echo generating machine-specific age key...
+          echo generating user-specific age key...
           ${pkgs.coreutils}/bin/mkdir -p $(${pkgs.coreutils}/bin/dirname ${escapedAgeKeyFile})
           # age-keygen sets 0600 by default, no need to chmod.
           ${pkgs.age}/bin/age-keygen -o ${escapedAgeKeyFile} ${lib.escapeShellArgs cfg.age.extraGenerateKeyArgs}

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -124,7 +124,7 @@ let
           echo generating machine-specific age key...
           ${pkgs.coreutils}/bin/mkdir -p $(${pkgs.coreutils}/bin/dirname ${escapedAgeKeyFile})
           # age-keygen sets 0600 by default, no need to chmod.
-          ${pkgs.age}/bin/age-keygen -o ${escapedAgeKeyFile}
+          ${pkgs.age}/bin/age-keygen -o ${escapedAgeKeyFile} ${lib.escapeShellArgs cfg.age.extraGenerateKeyArgs}
         fi
       ''
       + ''
@@ -267,6 +267,15 @@ in
         '';
       };
 
+      extraGenerateKeyArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "-pq" ];
+        description = ''
+          List of arguments to use when generating the age key.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = [ ];
@@ -346,6 +355,14 @@ in
             && cfg.gnupg.qubes-split-gpg.domain != ""
           );
         message = "sops.gnupg.qubes-split-gpg.domain is required when sops.gnupg.qubes-split-gpg.enable is set to true";
+      }
+      {
+        assertion =
+          !(
+            builtins.elem "-o" cfg.age.extraGenerateKeyArgs
+            || builtins.elem "--output" cfg.age.extraGenerateKeyArgs
+          );
+        message = "Cannot use '-o' or '--output' in sops.age.extraGenerateKeyArgs. The output path is managed by sops.age.keyFile.";
       }
     ];
 

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -173,7 +173,7 @@ let
             echo generating machine-specific age key...
             mkdir -p "$(dirname ${escapedKeyFile})"
             # age-keygen sets 0600 by default, no need to chmod.
-            ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile}
+            ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile} ${lib.escapeShellArgs cfg.age.extraGenerateKeyArgs}
           fi
         ''
       else
@@ -300,6 +300,15 @@ in
         '';
       };
 
+      extraGenerateKeyArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "-pq" ];
+        description = ''
+          List of arguments to use when generating the age key.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
@@ -368,6 +377,14 @@ in
           {
             assertion = !(cfg.gnupg.home != null && cfg.gnupg.sshKeyPaths != [ ]);
             message = "Exactly one of sops.gnupg.home and sops.gnupg.sshKeyPaths must be set";
+          }
+          {
+            assertion =
+              !(
+                builtins.elem "-o" cfg.age.extraGenerateKeyArgs
+                || builtins.elem "--output" cfg.age.extraGenerateKeyArgs
+              );
+            message = "Cannot use '-o' or '--output' in sops.age.extraGenerateKeyArgs. The output path is managed by sops.age.keyFile.";
           }
         ]
         ++ lib.optionals cfg.validateSopsFiles (

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -361,6 +361,15 @@ in
         '';
       };
 
+      extraGenerateKeyArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "-pq" ];
+        description = ''
+          List of arguments to use when generating the age key.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
@@ -444,6 +453,14 @@ in
             assertion = !(cfg.gnupg.home != null && cfg.gnupg.sshKeyPaths != [ ]);
             message = "Exactly one of sops.gnupg.home and sops.gnupg.sshKeyPaths must be set";
           }
+          {
+            assertion =
+              !(
+                builtins.elem "-o" cfg.age.extraGenerateKeyArgs
+                || builtins.elem "--output" cfg.age.extraGenerateKeyArgs
+              );
+            message = "Cannot use '-o' or '--output' in sops.age.extraGenerateKeyArgs. The output path is managed by sops.age.keyFile.";
+          }
         ]
         ++ lib.optionals cfg.validateSopsFiles (
           lib.concatLists (
@@ -511,7 +528,7 @@ in
                 echo generating machine-specific age key...
                 mkdir -p $(dirname ${escapedKeyFile})
                 # age-keygen sets 0600 by default, no need to chmod.
-                ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile}
+                ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile} ${lib.escapeShellArgs cfg.age.extraGenerateKeyArgs}
               fi
             ''
           );

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -361,6 +361,15 @@ in
         '';
       };
 
+      extraGenerateKeyArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "-pq" ];
+        description = ''
+          List of arguments to use when generating the age key.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
@@ -443,6 +452,14 @@ in
           assertion = !(cfg.gnupg.home != null && cfg.gnupg.sshKeyPaths != [ ]);
           message = "Exactly one of sops.gnupg.home and sops.gnupg.sshKeyPaths must be set";
         }
+        {
+          assertion =
+            !(
+              builtins.elem "-o" cfg.age.extraGenerateKeyArgs
+              || builtins.elem "--output" cfg.age.extraGenerateKeyArgs
+            );
+          message = "Cannot use '-o' or '--output' in sops.age.extraGenerateKeyArgs. The output path is managed by sops.age.keyFile.";
+        }
       ]
       ++ lib.optionals cfg.validateSopsFiles (
         lib.concatLists (
@@ -522,7 +539,7 @@ in
                 echo generating machine-specific age key...
                 mkdir -p $(dirname ${escapedKeyFile})
                 # age-keygen sets 0600 by default, no need to chmod.
-                ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile}
+                ${pkgs.age}/bin/age-keygen -o ${escapedKeyFile} ${lib.escapeShellArgs cfg.age.extraGenerateKeyArgs}
               fi
             ''
           );


### PR DESCRIPTION
Add a flexible `sops.age.extraGenerateKeyArgs` option to the base/NixOS, home-manager, and darwin modules.

This enables:
- **Post-quantum key generation**: `age-keygen` currently offers option `-pq` for this. This is the primary driver behind the PR.
- **Future flexibility**: If `age-keygen` adds more options in the future, `sops-nix` users can use this escape hatch without waiting for new development.

## :speech_balloon: Seeking Feedback: Option Naming
Here are some options I'm considering:
- Rename `generateKey` to `keyGeneration.enable` & add `keyGeneration.extraArgs`
    - :+1: Explicitly groups the two options together
    - :-1: `keyFile` option is left out, despite also being relevant. `keyFile` impacts key generation, but also has a purpose outside of generation.
- `extraGenerateKeyArgs`
    - :+1: Non-invasive. No end user refactoring to get rid of rename warning.
    - :+1: All three options impacting key generation stay at the same nesting level
    - :-1: Implicit grouping, not explicit
    - :-1: Long/wordy

I like the first option better, but the second option is what is currently implemented. Let me know your thoughts!