### PR TITLE
darwin: include system paths with age plugin PATH

### DIFF
--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -403,7 +403,12 @@ in
       sops.environment.SOPS_GPG_EXEC = lib.mkIf (cfg.gnupg.home != null || cfg.gnupg.sshKeyPaths != [ ]) (
         lib.mkDefault "${cfg.gnupg.package}/bin/gpg"
       );
-      sops.environment.PATH = lib.mkIf (cfg.age.plugins != [ ]) (lib.makeBinPath cfg.age.plugins);
+      sops.environment.PATH =
+        let
+          pluginPaths = lib.makeBinPath cfg.age.plugins;
+          systemPaths = "/usr/bin:/bin:/usr/sbin:/sbin";
+        in
+        lib.concatStringsSep ":" (lib.filter (p: p != "") [ pluginPaths systemPaths ]);
     }
   ];
 }


### PR DESCRIPTION
Fixes #957.

---

Minimal reproducing example:
```
{
  description = "Minimal sops-nix issue 957 repro";

  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
    nix-darwin.url = "github:nix-darwin/nix-darwin";
    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
    sops-nix.url = "path:/Users/tiferrei/Developer/sops-nix";
  };

  outputs =
    {
      nix-darwin,
      sops-nix,
      ...
    }:
    {
      darwinConfigurations.test = nix-darwin.lib.darwinSystem {
        modules = [
          sops-nix.darwinModules.sops
          (
            { pkgs, ... }:
            {
              nixpkgs.hostPlatform = "aarch64-darwin";
              documentation.enable = false;
              system.stateVersion = 5;

              sops.validateSopsFiles = false;
              sops.defaultSopsFile = "/dev/null";
              sops.age.keyFile = "/tmp/sops-nix-test-age-key.txt";
              sops.age.plugins = [ (pkgs.writeShellScriptBin "age-plugin-test" ":") ];
              sops.secrets."issue-957" = { };
            }
          )
        ];
      };
    };
}
```

Currently, the produced `launchd` daemon command lacks needed system paths:

```
nix eval --raw .#darwinConfigurations.test.config.launchd.daemons.sops-install-secrets.command
```
```
sh -c '
echo "Setting up secrets..."
(
# shellcheck disable=SC2030,SC2031
  export PATH='\''/nix/store/hy2qqz7kfz0y5kind56lxa6p8rby6jck-age-plugin-test/bin'\''
  export SOPS_GPG_EXEC='\''/nix/store/cgh6iwzz5jgx9z5whka4vgj210i6npc6-gnupg-2.4.9/bin/gpg'\''
  /nix/store/mm1ncsav8d2is67r6jqkaw5b87kbr638-sops-install-secrets-0.0.1/bin/sops-install-secrets /nix/store/7m5xpp5g7kphqrqr1681530rxd2hrn99-manifest.json
)

'
```

After the patch (a la #891):

```
sh -c '
echo "Setting up secrets..."
(
# shellcheck disable=SC2030,SC2031
  export PATH='\''/nix/store/hy2qqz7kfz0y5kind56lxa6p8rby6jck-age-plugin-test/bin:/usr/bin:/bin:/usr/sbin:/sbin'\''
  export SOPS_GPG_EXEC='\''/nix/store/cgh6iwzz5jgx9z5whka4vgj210i6npc6-gnupg-2.4.9/bin/gpg'\''
  /nix/store/mm1ncsav8d2is67r6jqkaw5b87kbr638-sops-install-secrets-0.0.1/bin/sops-install-secrets /nix/store/7m5xpp5g7kphqrqr1681530rxd2hrn99-manifest.json
)

'
```