### PR TITLE
fix: use user domain instead of gui for hm sops-nix launchd agent

### DIFF
--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -395,11 +395,13 @@ in
     # Darwin: load secrets once on login
     launchd.agents.sops-nix = {
       enable = true;
+      domain = "user";
       config = {
         Program = script;
         EnvironmentVariables = cfg.environment;
         KeepAlive = false;
         RunAtLoad = true;
+        LimitLoadToSessionType = "Background";
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/SopsNix/stdout";
         StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/SopsNix/stderr";
       };
@@ -410,7 +412,7 @@ in
       let
         darwin =
           let
-            domain-target = "gui/$(id -u ${config.home.username})";
+            domain-target = "user/$(id -u ${config.home.username})";
           in
           ''
             /bin/launchctl bootout ${domain-target}/org.nix-community.home.sops-nix && true


### PR DESCRIPTION
## Problem

Home Manager sops-nix fails to activate on headless macOS servers. The activation script runs:

```bash
launchctl bootstrap gui/$(id -u) ...
```

which fails with:

```
Bootstrap failed: 125: Domain does not support specified action
```

The `gui/UID` domain only exists when the user has an Aqua (GUI) login session. Machines accessed exclusively via SSH (headless Mac Mini, EC2 Mac instances, CI build servers) never create this domain.

## Root cause

Two issues in `modules/home-manager/sops.nix`:

1. **Activation script hardcodes `gui/$(id -u …)`** — `gui/UID` domain requires an Aqua session
2. **LaunchAgent plist omits `LimitLoadToSessionType`** — defaults to `Aqua`, which maps to `gui/UID`

## Fix

The `user/UID` domain exists after any login — GUI or SSH (`pam_launchd.so` creates it). Background agents loaded into this domain do not require a graphical session.

Two-line change:

1. Set `LimitLoadToSessionType = "Background"` in the LaunchAgent plist so the agent is loadable into `user/UID`
2. Change activation script domain target from `gui/` to `user/`

## Evidence

**Home Manager's own launchd module** ([link](https://nix-community.github.io/home-manager/options/home-manager/launchd.html#opt-launchd.agents._name_.domain)) already supports this distinction:

> `launchd.agents.<name>.domain` — The launchd domain to bootstrap this agent into.
> The `gui` domain is appropriate for agents that need the user's Aqua session.
> The `user` domain is appropriate for background services that do not require a graphical login session.

**Apple's `launchd.plist(5)` man page** (shipped with every macOS release) defines four session types:
- `Aqua` — requires GUI login (maps to `gui/UID`)
- `Background` — per-user context, **parent of all sessions for a user** (maps to `user/UID`)
- `StandardIO` — non-GUI login sessions (SSH per-session)
- `LoginWindow` — pre-login context

**StackOverflow confirmation** ([link](https://stackoverflow.com/a/74732641)):

> The `user` domain is available after a login (such as through SSH), but to add a service to this domain your .plist must contain `LimitLoadToSessionType = Background`.

## Verified

| macOS machine | session type | before | after |
|---|---|---|---|
| MacBook (GUI login) | `gui/501` + `user/501` | works | works |
| Mac Mini M4 (SSH only) | `user/501` only | `125: Domain does not support` | works |

The `Background` session type covers both use cases — a single session type suffices without needing an array.
