### PR TITLE
Add support for sops native ssh keys + ssh key cmd

### DIFF
--- a/checks/nixos-test.nix
+++ b/checks/nixos-test.nix
@@ -253,6 +253,25 @@ in
     '';
   };
 
+  age-ssh-key-cmd = testers.runNixOSTest {
+    name = "sops-age-ssh-key-cmd";
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        imports = [ ../modules/sops ];
+        sops = {
+          defaultSopsFile = testAssets + "/secrets-native-ssh.yaml";
+          secrets.test_key = { };
+          age.sshKeyCmd = "${pkgs.coreutils}/bin/cat ${testAssets + "/ssh-ed25519-key"}";
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.succeed("cat /run/secrets/test_key | grep -q test_value")
+    '';
+  };
+
   pgp-keys = testers.runNixOSTest {
     name = "sops-pgp-keys";
     nodes.server =

--- a/checks/nixos-test.nix
+++ b/checks/nixos-test.nix
@@ -229,6 +229,30 @@ in
     '';
   };
 
+  age-ssh-key-file = testers.runNixOSTest {
+    name = "sops-age-ssh-key-file";
+    nodes.machine = {
+      imports = [ ../modules/sops ];
+      sops = {
+        defaultSopsFile = testAssets + "/secrets-native-ssh.yaml";
+        secrets.test_key = { };
+        age.sshKeyFile = "/etc/ssh-test-key";
+      };
+
+      # place file at a known location, and outside of the store to
+      # satisfy sops.age.sshKeyFile's pathNotInStore type.
+      environment.etc."ssh-test-key" = {
+        source = testAssets + "/ssh-ed25519-key";
+        mode = "0600";
+      };
+    };
+
+    testScript = ''
+      start_all()
+      machine.succeed("cat /run/secrets/test_key | grep -q test_value")
+    '';
+  };
+
   pgp-keys = testers.runNixOSTest {
     name = "sops-pgp-keys";
     nodes.server =

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -98,6 +98,7 @@ let
         gnupgHome = cfg.gnupg.home;
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
+        ageSshKeyFile = cfg.age.sshKeyFile;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
         placeholderBySecretName = cfg.placeholder;
         userMode = true;
@@ -267,11 +268,26 @@ in
         '';
       };
 
+      sshKeyFile = lib.mkOption {
+        type = lib.types.nullOr pathNotInStore;
+        default = null;
+        example = "/home/someuser/.ssh/id_ed25519";
+        description = ''
+          Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = [ ];
         description = ''
           Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
     };
@@ -327,6 +343,7 @@ in
           || cfg.gnupg.sshKeyPaths != [ ]
           || cfg.gnupg.qubes-split-gpg.enable == true
           || cfg.age.keyFile != null
+          || cfg.age.sshKeyFile != null
           || cfg.age.sshKeyPaths != [ ];
         message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home or sops.gnupg.qubes-split-gpg.enable";
       }

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -99,6 +99,7 @@ let
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
         ageSshKeyFile = cfg.age.sshKeyFile;
+        ageSshKeyCmd = cfg.age.sshKeyCmd;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
         placeholderBySecretName = cfg.placeholder;
         userMode = true;
@@ -280,6 +281,16 @@ in
         '';
       };
 
+      sshKeyCmd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Command that outputs a (non-password protected) ssh private key that will be used by age for sops decryption.
+
+          Uses native ssh key support in age and requires no conversion.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = [ ];
@@ -344,6 +355,7 @@ in
           || cfg.gnupg.qubes-split-gpg.enable == true
           || cfg.age.keyFile != null
           || cfg.age.sshKeyFile != null
+          || cfg.age.sshKeyCmd != null
           || cfg.age.sshKeyPaths != [ ];
         message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home or sops.gnupg.qubes-split-gpg.enable";
       }

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -300,12 +300,27 @@ in
         '';
       };
 
+      sshKeyFile = lib.mkOption {
+        type = lib.types.nullOr pathNotInStore;
+        default = null;
+        example = "/etc/ssh/ssh_host_ed25519_key";
+        description = ''
+          Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
         defaultText = lib.literalMD "The ed25519 keys from {option}`config.services.openssh.hostKeys`";
         description = ''
           Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
 
@@ -362,6 +377,7 @@ in
               cfg.gnupg.home != null
               || cfg.gnupg.sshKeyPaths != [ ]
               || cfg.age.keyFile != null
+              || cfg.age.sshKeyFile != null
               || cfg.age.sshKeyPaths != [ ];
             message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home";
           }

--- a/modules/nix-darwin/default.nix
+++ b/modules/nix-darwin/default.nix
@@ -311,6 +311,16 @@ in
           the native ssh key support in age and requires no conversion.
         '';
       };
+      
+      sshKeyCmd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Command that outputs a (non-password protected) ssh private key that will be used by age for sops decryption.
+
+          Uses native ssh key support in age and requires no conversion.
+        '';
+      };
 
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
@@ -378,6 +388,7 @@ in
               || cfg.gnupg.sshKeyPaths != [ ]
               || cfg.age.keyFile != null
               || cfg.age.sshKeyFile != null
+              || cfg.age.sshKeyCmd != null
               || cfg.age.sshKeyPaths != [ ];
             message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home";
           }

--- a/modules/nix-darwin/manifest-for.nix
+++ b/modules/nix-darwin/manifest-for.nix
@@ -15,6 +15,7 @@ writeTextFile {
       gnupgHome = cfg.gnupg.home;
       sshKeyPaths = cfg.gnupg.sshKeyPaths;
       ageKeyFile = cfg.age.keyFile;
+      ageSshKeyFile = cfg.age.sshKeyFile;
       ageSshKeyPaths = cfg.age.sshKeyPaths;
       useTmpfs = false;
       placeholderBySecretName = cfg.placeholder;

--- a/modules/nix-darwin/manifest-for.nix
+++ b/modules/nix-darwin/manifest-for.nix
@@ -16,6 +16,7 @@ writeTextFile {
       sshKeyPaths = cfg.gnupg.sshKeyPaths;
       ageKeyFile = cfg.age.keyFile;
       ageSshKeyFile = cfg.age.sshKeyFile;
+      ageSshKeyCmd = cfg.age.sshKeyCmd;
       ageSshKeyPaths = cfg.age.sshKeyPaths;
       useTmpfs = false;
       placeholderBySecretName = cfg.placeholder;

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -361,12 +361,27 @@ in
         '';
       };
 
+      sshKeyFile = lib.mkOption {
+        type = lib.types.nullOr pathNotInStore;
+        default = null;
+        example = "/etc/ssh/ssh_host_ed25519_key";
+        description = ''
+          Path to ssh key file that will be used by age for sops decryption.
+          
+          Unlike {option}`config.sops.age.sshKeyPaths`, this option makes use of
+          the native ssh key support in age and requires no conversion.
+        '';
+      };
+
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
         default = defaultImportKeys "ed25519";
         defaultText = lib.literalMD "The ed25519 keys from {option}`config.services.openssh.hostKeys`";
         description = ''
           Paths to ssh keys added as age keys during sops description.
+          
+          These ssh keys will be converted into age keys automatically using
+          ssh-to-age before they are fed to age.
         '';
       };
     };
@@ -436,6 +451,7 @@ in
             cfg.gnupg.home != null
             || cfg.gnupg.sshKeyPaths != [ ]
             || cfg.age.keyFile != null
+            || cfg.age.sshKeyFile != null
             || cfg.age.sshKeyPaths != [ ];
           message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home";
         }

--- a/modules/sops/default.nix
+++ b/modules/sops/default.nix
@@ -372,6 +372,16 @@ in
           the native ssh key support in age and requires no conversion.
         '';
       };
+      
+      sshKeyCmd = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Command that outputs a (non-password protected) ssh private key that will be used by age for sops decryption.
+
+          Uses native ssh key support in age and requires no conversion.
+        '';
+      };
 
       sshKeyPaths = lib.mkOption {
         type = lib.types.listOf lib.types.path;
@@ -452,6 +462,7 @@ in
             || cfg.gnupg.sshKeyPaths != [ ]
             || cfg.age.keyFile != null
             || cfg.age.sshKeyFile != null
+            || cfg.age.sshKeyCmd != null
             || cfg.age.sshKeyPaths != [ ];
           message = "No key source configured for sops. Either set services.openssh.enable or set sops.age.keyFile or sops.gnupg.home";
         }

--- a/modules/sops/manifest-for.nix
+++ b/modules/sops/manifest-for.nix
@@ -40,6 +40,7 @@ else
         gnupgHome = cfg.gnupg.home;
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
+        ageSshKeyFile = cfg.age.sshKeyFile;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
         useTmpfs = cfg.useTmpfs;
         placeholderBySecretName = cfg.placeholder;

--- a/modules/sops/manifest-for.nix
+++ b/modules/sops/manifest-for.nix
@@ -41,6 +41,7 @@ else
         sshKeyPaths = cfg.gnupg.sshKeyPaths;
         ageKeyFile = cfg.age.keyFile;
         ageSshKeyFile = cfg.age.sshKeyFile;
+        ageSshKeyCmd = cfg.age.sshKeyCmd;
         ageSshKeyPaths = cfg.age.sshKeyPaths;
         useTmpfs = cfg.useTmpfs;
         placeholderBySecretName = cfg.placeholder;

--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -81,6 +81,7 @@ type manifest struct {
 	GnupgHome               string            `json:"gnupgHome"`
 	AgeKeyFile              string            `json:"ageKeyFile"`
 	AgeSSHKeyFile           string            `json:"ageSshKeyFile"`
+	AgeSSHKeyCmd            string            `json:"ageSshKeyCmd"`
 	AgeSSHKeyPaths          []string          `json:"ageSshKeyPaths"`
 	UseTmpfs                bool              `json:"useTmpfs"`
 	UserMode                bool              `json:"userMode"`
@@ -1398,7 +1399,7 @@ func installSecrets(args []string) error {
 	}
 
 	// Import age keys
-	if (len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "") && manifest.AgeSSHKeyFile == "" {
+	if (len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "") && manifest.AgeSSHKeyFile == "" && manifest.AgeSSHKeyCmd == "" {
 		keyfile := filepath.Join(manifest.SecretsMountPoint, "age-keys.txt")
 		err = os.Setenv("SOPS_AGE_KEY_FILE", keyfile)
 		if err != nil {
@@ -1441,6 +1442,13 @@ func installSecrets(args []string) error {
 
 	if manifest.AgeSSHKeyFile != "" {
 		err = os.Setenv("SOPS_AGE_SSH_PRIVATE_KEY_FILE", manifest.AgeSSHKeyFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	if manifest.AgeSSHKeyCmd != "" {
+		err = os.Setenv("SOPS_AGE_SSH_PRIVATE_KEY_CMD", manifest.AgeSSHKeyCmd)
 		if err != nil {
 			return err
 		}

--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -80,6 +80,7 @@ type manifest struct {
 	SSHKeyPaths             []string          `json:"sshKeyPaths"`
 	GnupgHome               string            `json:"gnupgHome"`
 	AgeKeyFile              string            `json:"ageKeyFile"`
+	AgeSSHKeyFile           string            `json:"ageSshKeyFile"`
 	AgeSSHKeyPaths          []string          `json:"ageSshKeyPaths"`
 	UseTmpfs                bool              `json:"useTmpfs"`
 	UserMode                bool              `json:"userMode"`
@@ -1397,7 +1398,7 @@ func installSecrets(args []string) error {
 	}
 
 	// Import age keys
-	if len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "" {
+	if (len(manifest.AgeSSHKeyPaths) != 0 || manifest.AgeKeyFile != "") && manifest.AgeSSHKeyFile == "" {
 		keyfile := filepath.Join(manifest.SecretsMountPoint, "age-keys.txt")
 		err = os.Setenv("SOPS_AGE_KEY_FILE", keyfile)
 		if err != nil {
@@ -1435,6 +1436,13 @@ func installSecrets(args []string) error {
 			if err != nil {
 				return fmt.Errorf("cannot write key to age file: %w", err)
 			}
+		}
+	}
+
+	if manifest.AgeSSHKeyFile != "" {
+		err = os.Setenv("SOPS_AGE_SSH_PRIVATE_KEY_FILE", manifest.AgeSSHKeyFile)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkgs/sops-install-secrets/main_test.go
+++ b/pkgs/sops-install-secrets/main_test.go
@@ -345,6 +345,41 @@ func TestAgeWithSSHKeyFile(t *testing.T) {
 	testInstallSecret(t, testdir, &m)
 }
 
+func TestAgeWithSSHKeyCmd(t *testing.T) {
+	assets := testAssetPath()
+
+	testdir := newTestDir(t)
+	defer testdir.Remove()
+
+	target := path.Join(testdir.path, "existing-target")
+	file, err := os.Create(target)
+	ok(t, err)
+	_ = file.Close()
+
+	nobody := "nobody"
+	nogroup := "nogroup"
+	s := secret{
+		Name:         "test",
+		Key:          "test_key",
+		Owner:        &nobody,
+		Group:        &nogroup,
+		SopsFile:     path.Join(assets, "secrets-native-ssh.yaml"),
+		Path:         target,
+		Mode:         "0400",
+		RestartUnits: []string{"affected-service"},
+		ReloadUnits:  []string{"affected-reload-service"},
+	}
+
+	m := manifest{
+		Secrets:           []secret{s},
+		SecretsMountPoint: testdir.secretsPath,
+		SymlinkPath:       testdir.symlinkPath,
+		AgeSSHKeyCmd:      fmt.Sprintf("cat %s", path.Join(assets, "ssh-ed25519-key")),
+	}
+
+	testInstallSecret(t, testdir, &m)
+}
+
 func TestAll(t *testing.T) {
 	// we can't test in parallel because we rely on GNUPGHOME environment variable
 	testGPG(t)

--- a/pkgs/sops-install-secrets/main_test.go
+++ b/pkgs/sops-install-secrets/main_test.go
@@ -310,6 +310,41 @@ func TestAgeWithSSH(t *testing.T) {
 	testInstallSecret(t, testdir, &m)
 }
 
+func TestAgeWithSSHKeyFile(t *testing.T) {
+	assets := testAssetPath()
+
+	testdir := newTestDir(t)
+	defer testdir.Remove()
+
+	target := path.Join(testdir.path, "existing-target")
+	file, err := os.Create(target)
+	ok(t, err)
+	_ = file.Close()
+
+	nobody := "nobody"
+	nogroup := "nogroup"
+	s := secret{
+		Name:         "test",
+		Key:          "test_key",
+		Owner:        &nobody,
+		Group:        &nogroup,
+		SopsFile:     path.Join(assets, "secrets-native-ssh.yaml"),
+		Path:         target,
+		Mode:         "0400",
+		RestartUnits: []string{"affected-service"},
+		ReloadUnits:  []string{"affected-reload-service"},
+	}
+
+	m := manifest{
+		Secrets:           []secret{s},
+		SecretsMountPoint: testdir.secretsPath,
+		SymlinkPath:       testdir.symlinkPath,
+		AgeSSHKeyFile:     path.Join(assets, "ssh-ed25519-key"),
+	}
+
+	testInstallSecret(t, testdir, &m)
+}
+
 func TestAll(t *testing.T) {
 	// we can't test in parallel because we rely on GNUPGHOME environment variable
 	testGPG(t)

--- a/pkgs/sops-install-secrets/test-assets/secrets-native-ssh.yaml
+++ b/pkgs/sops-install-secrets/test-assets/secrets-native-ssh.yaml
@@ -1,0 +1,51 @@
+test_key: ENC[AES256_GCM,data:TqlrhelNtC0QxQ==,iv:Kn/T9IyOAiHkJbVBCR7SIq+SYxb3Uf+hsUyb7OV81eg=,tag:1DANWLc1w0KQvi7g7Mrlmg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IE5hNFZOZyBhbzNU
+            aWk4eWQ2Qjc3MnZhSjJzMFhtYjVvM1BmbXU1cHdlSWJ3eFprWlVvCnlwenJvL1B4
+            bFBkU2dXMmx1d3lxZHg2REJRY0JLMVh6d2lseDRqRnduVHcKLS0tIFJ5NnJWWjlF
+            cWlaWTMxY2hrU2picU01WFM5VS8vN3ZQUCtSbC9DRzRmaGMKicaLiQ1dsv6bMQFU
+            SGo06mlkfmgV5OVzFsWIQIk7QmaKrwPRfpuFHyFQ8Xjy0guqqdTgw4NOOtbPbWr6
+            oC6EjQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBI1+Q+ntzANebtnicCiAY29uqLGWOaOGLEa8bUqOVmS
+    lastmodified: "2026-08-01T09:00:14Z"
+    mac: ENC[AES256_GCM,data:I16RSRAjONWW8hA5c/dm2Wtlm4ZJqGMalquSQztHZHzi7++6W6ktDyG7ApVpeHTva4nxtm5D/ydBixlShGOUHysJhnmiHhoO5fncd8sjzhSbn2P6bZ1hL+9FP+mcQxcGNMxjogAvZ5cQcrJavNShF5SFgxibZu5tJf1Bsmk5tBE=,iv:rVeS9TJfH/3Nt0hDSX/eEkUzpLKG/LbYc8njpm9mEsw=,tag:TU8oaDiseT63romw8jfq1Q==,type:str]
+    pgp:
+        - created_at: "2026-08-01T09:00:14Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/m6nevQP1fAAQgAk75mN38iLhWLhulqsu8gC0DGmf+//VB6vh3dCC+SHS4z
+            K9wUiMD9wz/CKSxR/UUE9R3f+ofLqTTMAkgQ1Vs826Eym2lP6LXLKrnzSU1Amm0h
+            OfTA95RJs9gQLtkZSg4j5tC0wkH4pH0JgePR0Lr/QKqLxVYxkdHMR59VQwsok5Nr
+            vliwLK6SMWuofgjPpVDi3XGQSoE2JeKxL7ewfX9HovnbRlVVZh2dP7MqfsgkU4DV
+            dgLR19rm1qQaduzSJ1E5NV2Ocuw1xUpEOdjAzS4hliMy4sfjiC64y7ALA5YWNys+
+            KT8LlebsDIsZcDQLPyD8obx+bpTJL96d7PDKECpovdJeAdkNnmicPfjJA3NFrtbg
+            CDr9IEtlIf3KbTesr6DRmzbmEtvhbkIPTONjJwmcFDz2qTsKfYbptsVqPpWL3HQd
+            +WJvM8aDOIh/aoT7m3iH2hsJC40yDqppx5QNOcQr8w==
+            =8A9p
+            -----END PGP MESSAGE-----
+          fp: 7FB89715AADA920D65D25E63F9BA9DEBD03F57C0
+        - created_at: "2026-08-01T09:00:14Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA3ulPRkZxd/UAQwAlUgu13gAkr75n+l53XefEhk1uPspL3y9we5VbOB180I2
+            FeUlS+JnyroHHj65hA0FAmw0Poyrpoq4lW2/eZzXnhl9d+FrVW2+T7+pHWnt3/MY
+            NTzKQytV19P7KwxF/sj7BLVPC/A0Muq7dtAsaAdTR40cR0+OQtMjiHAQjG4+b5lQ
+            7kTgmaTEq8x+6P1u/u8qY9uTHbDgIq4v+aIJ6EN40JCw6ZP+QZaFDJoZbmnxr/SP
+            /vvfSadAYHoYrvt5rMSngHcdSjSX/t0++JsheN3RsVsajbuIRr5aK28LMdUz8Xdh
+            n3ZrWCR7rVsNEDSdDtWkuCa9nIa1PSoLOLseS2PSJxPeTW48FmayvIE9wCB+LKOU
+            USlnXErUv+tmyNP9Bi5YPcL4ai8F5+h83r0lYYFe/nI2ItY6ohZT+RI1OrMa9QQO
+            e4hjjychvmYiUII6QKRJMi0Aj6YSd3axa7JVbohlsXf2sXqraI0438f6iFcgBqai
+            Dt/TgevRv02n5go83vNl0lgBrJBfjeQ668I5pPw66RsN7OfrW7gXgcFt1uQQ+Bmy
+            DcN1S0khj/ZOCipIBA2CfbzyCuCzP2N17eZNwU2kYTqp2xASFuckwhksW6/9b2HV
+            sdDCFoXhlRtG
+            =cXy0
+            -----END PGP MESSAGE-----
+          fp: 2504791468B153B8A3963CC97BA53D1919C5DFD4
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
This is just the work from #779  and #922 (with a small fix, as it didn't evaluate on "normal" nix), and rebased against master.
I'll try to keep this up-to-date and rebased as long as I can, but hopefully we can get this merged.
I'm currently using this on multiple systems, and multiple different deployments, and thus far it seems to work just fine.

This also adds basic tests in both the Golang code, as well an nix tests for both newly added options. 