### PR TITLE
sops-install-secrets: skip invalid secrets instead of aborting the whole run

### DIFF
--- a/pkgs/sops-install-secrets/main.go
+++ b/pkgs/sops-install-secrets/main.go
@@ -156,6 +156,16 @@ type appContext struct {
 	secretByPlaceholder map[string]*secret
 	checkMode           CheckMode
 	ignorePasswd        bool
+	// Secrets dropped by validation, reported after the healthy ones are in.
+	skipped []error
+}
+
+func (app *appContext) skippedError() error {
+	if len(app.skipped) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d of %d secrets were skipped: %w",
+		len(app.skipped), len(app.skipped)+len(app.manifest.Secrets), errors.Join(app.skipped...))
 }
 
 // Keep this in sync with `modules/sops/templates/default.nix`
@@ -729,15 +739,26 @@ func (app *appContext) validateManifest() error {
 		}
 	}
 
+	// A broken secret only disables itself; the rest are still installed and
+	// the collected errors are reported once everything else is done.
+	kept := 0
 	for i := range m.Secrets {
 		secret := &m.Secrets[i]
 		if err := app.validateSecret(secret); err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "skipping secret '%s': %s\n", secret.Name, err)
+			app.skipped = append(app.skipped, err)
+			continue
 		}
+		m.Secrets[kept] = *secret
+		kept++
+	}
+	m.Secrets = m.Secrets[:kept]
 
-		// The Nix module only defines placeholders for secrets if there are
-		// templates.
-		if len(m.Templates) > 0 {
+	// The Nix module only defines placeholders for secrets if there are
+	// templates.
+	if len(m.Templates) > 0 {
+		for i := range m.Secrets {
+			secret := &m.Secrets[i]
 			placeholder, present := m.PlaceholderBySecretName[secret.Name]
 			if !present {
 				return fmt.Errorf("placeholder for %s not found in manifest", secret.Name)
@@ -1361,8 +1382,14 @@ func installSecrets(args []string) error {
 	if err = app.validateManifest(); err != nil {
 		return fmt.Errorf("manifest is not valid: %w", err)
 	}
+	// validateManifest drops the secrets it rejected.
+	manifest.Secrets = app.manifest.Secrets
 
+	// Checks are build-time gates, so nothing is tolerated there.
 	if app.checkMode != Off {
+		if err := app.skippedError(); err != nil {
+			return fmt.Errorf("manifest is not valid: %w", err)
+		}
 		return nil
 	}
 
@@ -1464,7 +1491,7 @@ func installSecrets(args []string) error {
 	}
 	// No need to perform the actual symlinking
 	if isDry {
-		return nil
+		return app.skippedError()
 	}
 	if err := atomicSymlink(*secretDir, manifest.SymlinkPath); err != nil {
 		return fmt.Errorf("cannot update secrets symlink: %w", err)
@@ -1476,7 +1503,7 @@ func installSecrets(args []string) error {
 		return fmt.Errorf("cannot prune old secrets generations: %w", err)
 	}
 
-	return nil
+	return app.skippedError()
 }
 
 func main() {

--- a/pkgs/sops-install-secrets/main_test.go
+++ b/pkgs/sops-install-secrets/main_test.go
@@ -275,6 +275,55 @@ func TestAge(t *testing.T) {
 	testInstallSecret(t, testdir, &m)
 }
 
+// A secret whose owner does not exist must not hold back the other secrets.
+func TestSkipsSecretWithUnknownOwner(t *testing.T) {
+	assets := testAssetPath()
+
+	testdir := newTestDir(t)
+	defer testdir.Remove()
+
+	nobody := "nobody"
+	nogroup := "nogroup"
+	good := secret{
+		Name:         "good",
+		Key:          "test_key",
+		Owner:        &nobody,
+		Group:        &nogroup,
+		SopsFile:     path.Join(assets, "secrets.yaml"),
+		Path:         path.Join(testdir.path, "good-target"),
+		Mode:         "0400",
+		RestartUnits: []string{},
+		ReloadUnits:  []string{},
+	}
+
+	unknown := "no-such-user-for-test"
+	bad := good
+	bad.Name = "bad"
+	bad.Owner = &unknown
+	bad.Path = path.Join(testdir.path, "bad-target")
+
+	// Deliberately first: it used to abort the whole run.
+	m := manifest{
+		Secrets:           []secret{bad, good},
+		SecretsMountPoint: testdir.secretsPath,
+		SymlinkPath:       testdir.symlinkPath,
+		AgeKeyFile:        path.Join(assets, "age-keys.txt"),
+	}
+
+	manifestPath := writeManifest(t, testdir.path, &m)
+	if err := installSecrets([]string{"sops-install-secrets", manifestPath}); err == nil {
+		t.Fatal("expected a non-nil error reporting the skipped secret")
+	}
+
+	content, err := os.ReadFile(good.Path)
+	ok(t, err)
+	equals(t, "test_value", string(content))
+
+	if _, err := os.Lstat(bad.Path); !os.IsNotExist(err) {
+		t.Fatalf("skipped secret was installed at %s", bad.Path)
+	}
+}
+
 func TestAgeWithSSH(t *testing.T) {
 	assets := testAssetPath()
 


### PR DESCRIPTION
Fixes #972.

`validateManifest` returned on the first bad secret, before anything was decrypted, so one secret with an unresolvable `owner` left the machine with no secrets at all.

Now such secrets are skipped individually, the rest are installed, and the collected errors are returned at the end — activation still fails, but the box keeps working. Check modes (`-check-mode=`) stay strict, since those are build-time gates.

Test added: fails on master (the healthy secret is missing), passes here.
