### PR TITLE
fix: use hostPlatform for platform checks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,7 @@ rec {
     inherit sops-install-secrets;
   };
 }
-// pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+// pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   cross-build = pkgs.callPackage ./pkgs/cross-build.nix {
     inherit sops-install-secrets;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -103,9 +103,9 @@
             home-manager = self.legacyPackages.${system}.homeConfigurations.sops.activation-script;
           }
           // (suffix-stable packages-stable)
-          // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux tests
-          // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux (suffix-stable tests-stable)
-          // nixpkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux tests
+          // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (suffix-stable tests-stable)
+          // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
             darwin-sops =
               self.darwinConfigurations."sops-${pkgs.stdenv.hostPlatform.darwinArch}".config.system.build.toplevel;
           }

--- a/modules/home-manager/sops.nix
+++ b/modules/home-manager/sops.nix
@@ -368,7 +368,7 @@ in
       PATH =
         let
           pluginPaths = lib.makeBinPath cfg.age.plugins;
-          systemPaths = lib.optionalString pkgs.stdenv.isDarwin "/usr/bin:/bin:/usr/sbin:/sbin";
+          systemPaths = lib.optionalString pkgs.stdenv.hostPlatform.isDarwin "/usr/bin:/bin:/usr/sbin:/sbin";
         in
         lib.concatStringsSep ":" (lib.filter (p: p != "") [ pluginPaths systemPaths ]);
 
@@ -435,7 +435,7 @@ in
 
       in
       {
-        sops-nix = if pkgs.stdenv.isLinux then linux else darwin;
+        sops-nix = if pkgs.stdenv.hostPlatform.isLinux then linux else darwin;
       };
   };
 }

--- a/pkgs/sops-install-secrets/default.nix
+++ b/pkgs/sops-install-secrets/default.nix
@@ -20,13 +20,13 @@ buildGo125Module {
   # requires root privileges for tests
   doCheck = false;
 
-  outputs = [ "out" ] ++ lib.optional stdenv.isLinux "unittest";
+  outputs = [ "out" ] ++ lib.optional stdenv.hostPlatform.isLinux "unittest";
 
   postInstall =
     ''
       go test -c ./pkgs/sops-install-secrets
     ''
-    + lib.optionalString stdenv.isLinux ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
       # *.test is only tested on linux. $unittest does not exist on darwin.
       install -D ./sops-install-secrets.test $unittest/bin/sops-install-secrets.test
       # newer versions of nixpkgs no longer require this step

--- a/pkgs/unit-tests.nix
+++ b/pkgs/unit-tests.nix
@@ -9,12 +9,12 @@ pkgs.writeShellApplication {
   runtimeInputs = [
     pkgs.gnupg
     pkgs.nix
-  ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+  ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
     pkgs.util-linux
   ];
   text = ''
     NIX_PATH=nixpkgs=${pkgs.path} TEST_ASSETS="$PWD/pkgs/sops-pgp-hook/test-assets" ${sopsPkgs.sops-pgp-hook-test}/bin/sops-pgp-hook.test -test.v
-    ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+    ${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
       sudo TEST_ASSETS="$PWD/pkgs/sops-install-secrets/test-assets" unshare --mount --fork ${sopsPkgs.sops-install-secrets.unittest}/bin/sops-install-secrets.test -test.v
     ''}
   '';


### PR DESCRIPTION
nixos-unstable-small currently emits deprecation warnings because sops-nix accesses stdenv.isLinux/isDarwin. Replace these with stdenv.hostPlatform.isLinux/isDarwin to avoid the warnings.